### PR TITLE
Grafana and Tempo updates

### DIFF
--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:10.0.1
+        image: docker.io/grafana/grafana:10.0.2
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -83,7 +83,7 @@ spec:
       volumes:
         - name: tempo-storage
           emptyDir:
-            sizeLimit: "5Gi"
+            sizeLimit: "10Gi"
         - configMap:
             name: tempo
           name: tempo-conf

--- a/deployment/tempo/tempo-cm.yml
+++ b/deployment/tempo/tempo-cm.yml
@@ -45,9 +45,13 @@ data:
     storage:
       trace:
         backend: local
+        block:
+          version: vParquet
+          v2_encoding: zstd
         local:
           path: /var/tempo/traces
         wal:
+          v2_encoding: snappy
           path: /var/tempo/wal
     querier: {}
     query_frontend: {}


### PR DESCRIPTION
- version bump for Kubernetes Grafana container tag
- Increased Tempo ephemeral volume size to 10Gi, and added Temp config storage version and v2_encoding
