### PR TITLE
Tempo block vParquet2

### DIFF
--- a/deployment/tempo/tempo-cm.yml
+++ b/deployment/tempo/tempo-cm.yml
@@ -46,7 +46,9 @@ data:
       trace:
         backend: local
         block:
-          version: vParquet
+          # There vParquet2 is a performance gain for TraceQL queries containing duration. it will also be a prerequisite for TraceQL structural operators
+          # For full details: https://github.com/grafana/tempo/pull/2244
+          version: vParquet2
           v2_encoding: zstd
         local:
           path: /var/tempo/traces


### PR DESCRIPTION
Due to the dedicated span duration column, there is a performance gain for TraceQL queries containing duration. vParquet2 will also be a prerequisite for TraceQL’s structural operators, which will be introduced in a future release.
