### PR TITLE
Tempo version bump to 2.2.1

### DIFF
--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -24,7 +24,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
-        image: grafana/tempo:2.2.0
+        image: grafana/tempo:2.2.1
         imagePullPolicy: IfNotPresent
         name: tempo
         ports:


### PR DESCRIPTION
This fixes panic in metrics generator, for full details: https://github.com/grafana/tempo/releases/tag/v2.2.1
