### PR TITLE
feat: promethues add record rule

### DIFF
--- a/deployment/prometheus/cm.yml
+++ b/deployment/prometheus/cm.yml
@@ -8,6 +8,18 @@ metadata:
 data:
   alerting_rules.yml: |
     groups:
+    - name: http_request_duration
+      rules:
+      - record: job:request_duration_seconds:rate
+        expr: |
+          sum(rate(hubble_http_request_duration_seconds_bucket{
+            cluster=~"${cluster}",
+            destination_namespace=~"${destination_namespace}",
+            destination_workload=~"${destination_workload}",
+            reporter="${reporter}",
+            source_namespace=~"${source_namespace}",
+            source_workload=~"${source_workload}"
+          }[5m])) by (cluster, destination_namespace, destination_workload, le)
     - name: Memory
       rules:
       - alert: ContainerUsedMemoryPercent


### PR DESCRIPTION
Add http_request_duration record rule that captures the aggregated rates. This way, we only write the aggregated rule once and reuse it for different quantiles i.e.
