### PR TITLE
service minor version bump

### DIFF
--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:11.6.0
+        image: docker.io/grafana/grafana:11.6.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -30,7 +30,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.4.3
+          image: docker.io/grafana/loki:3.5.0
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"

--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -52,7 +52,7 @@ spec:
         - '-store-gateway.sharding-ring.replication-factor=1'
         - '-ingester.out-of-order-time-window=5m'
         - '-blocks-storage.bucket-store.ignore-blocks-within=0s'
-        image: grafana/mimir:2.15.0
+        image: grafana/mimir:2.16.0
         imagePullPolicy: IfNotPresent
         name: mimir
         ports:

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v3.2.1
+          image: docker.io/prom/prometheus:v3.3.0
           imagePullPolicy: IfNotPresent
           args:
             - '--storage.tsdb.retention.time=15d'

--- a/deployment/promtail/daemonset.yml
+++ b/deployment/promtail/daemonset.yml
@@ -24,7 +24,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:3.4.3
+          image: docker.io/grafana/promtail:3.5.0
           imagePullPolicy: IfNotPresent
           env:
           - name: HOSTNAME


### PR DESCRIPTION
- **chore: grafana version bump to v11.6.1**
- **chore: mimir version bump to v2.16.0**
- **chore: loki and promtail version bump to v3.5.0**
- **chore: prometheus version bump to v3.3.0**
