### PR TITLE
chore: Increase Grafana ephemeral emptyDir storage allocation

### DIFF
--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -104,4 +104,4 @@ spec:
             name: datasources
         - name: grafana-storage
           emptyDir:
-            sizeLimit: "1Gi"
+            sizeLimit: "2Gi"


### PR DESCRIPTION
## Summary

This change increases the Grafana ephemeral emptyDir storage allocation from 1Gi to 2Gi to accommodate additional plugins that require extra space for installation and operation.

## Changes Made

- Updated `deployment/grafana/deployment.yml` to increase the `grafana-storage` emptyDir volume size limit from 1Gi to 2Gi

## Rationale

The additional plugins feature being enabled requires more storage space than the current 1Gi allocation provides. This increase ensures stable Grafana operation without storage-related failures during plugin installation and runtime.

## Testing

- [x] Deployment tested with increased storage allocation
- [x] Grafana starts successfully with additional plugins enabled
- [x] No storage-related errors observed

Resolves #162