### PR TITLE
chore: add nodes/proxy permission to Prometheus cluster role

### DIFF
--- a/deployment/prometheus/rbac.yml
+++ b/deployment/prometheus/rbac.yml
@@ -11,6 +11,7 @@ rules:
     resources:
       - nodes
       - nodes/metrics
+      - nodes/proxy
       - services
       - endpoints
       - pods


### PR DESCRIPTION
## Description
Add `nodes/proxy` resource permission to the Prometheus ClusterRole to enable proper node-level monitoring functionality.

## Changes
- Added `nodes/proxy` to the resources list in `deployment/prometheus/rbac.yml`

## Impact
This enables Prometheus to access node proxy resources for enhanced monitoring capabilities and node-level metrics collection.

Resolves: #165