### PR TITLE
chore: update Grafana to v12.1.0 and enhance Mimir alert rules configuration

### DIFF
--- a/deployment/grafana/cm.yml
+++ b/deployment/grafana/cm.yml
@@ -44,9 +44,12 @@ data:
       editable: true
       url: http://mimir/prometheus
       jsonData:
+        exemplarTraceIdDestinations:
+        - name: trace_id
+          datasourceUid: Tempo
         manageAlerts: true
-        maxLines: 1000
         prometheusType: Mimir
+        maxLines: 1000
   pyroscope.yaml: |-
     apiVersion: 1
     datasources:
@@ -107,11 +110,17 @@ data:
           filterByTraceID: true
         tracesToProfiles:
           datasourceUid: Pyroscope
+          tags: ['job', 'instance', 'pod', 'namespace']
+          profileTypeId: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'
+          customQuery: true
+          query: 'method="$${__span.tags.method}"'
         tracesToMetrics:
           datasourceUid: Prometheus
         serviceMap:
           datasourceUid: Prometheus
         nodeGraph:
           enabled: true
+        search:
+          hide: false
         lokiSearch:
           datasourceUid: Loki

--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:12.0.2
+        image: docker.io/grafana/grafana:12.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -76,6 +76,9 @@ spec:
           mountPath: /rules
         - name: ruler
           mountPath: /ruler
+        - name: annonymous
+          mountPath: /rules/anonymous
+          subPath: anonymous
         - name: tsdb
           mountPath: /tsdb
         - name: tsdb-sync


### PR DESCRIPTION
Resolves: #184 

This PR includes two main sets of changes:

1. **Grafana Updates and Configuration Enhancements**:
- Upgraded Grafana from v12.0.2 to v12.1.0
- Added exemplar trace ID destinations configuration for Tempo datasource
- Enhanced traces-to-profiles settings with additional tags, profile type, and custom query
- Enabled additional visualization options including search and node graph
- Improved Pyroscope and Loki datasource configurations

2. **Mimir Alert Rules Configuration**:
- Added new anonymous alert rules path configuration
- Updated statefulset to mount the anonymous rules directory

These changes improve observability capabilities and maintain compatibility with the latest Grafana features.