### PR TITLE
chore(prometheus): infer procs and mem from resources spec

### DIFF
--- a/deployment/prometheus/cm.yml
+++ b/deployment/prometheus/cm.yml
@@ -119,9 +119,9 @@ data:
       evaluation_interval: 1m
       scrape_interval: 1m
       scrape_timeout: 10s
-    remote_write:
-    - name: mimir
-      url: http://mimir/api/v1/push
+    # remote_write:
+    # - name: mimir
+    #   url: http://mimir/api/v1/push
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -27,6 +27,17 @@ spec:
         - name: prometheus
           image: docker.io/prom/prometheus:v3.5.0
           imagePullPolicy: IfNotPresent
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.memory
           args:
             - '--storage.tsdb.retention.time=15d'
             - '--config.file=/etc/prometheus/prometheus.yml'
@@ -39,8 +50,6 @@ spec:
             - '--web.enable-lifecycle'
             - '--log.level=warn'
             - '--log.format=json'
-            - '--no-auto-gomaxprocs'
-            - '--no-auto-gomemlimit'
           ports:
             - containerPort: 9090
               name: http
@@ -55,7 +64,7 @@ spec:
           resources:
             limits:
               cpu: 150m
-              memory: 768Mi
+              memory: 894Mi
             requests:
               cpu: 100m
               memory: 512Mi


### PR DESCRIPTION
This will set GOMAXPROCS and GOMEMLIMIT to match the limits set configured spec, which is the recommended Kubernetes-native way.

CFS throttling is enforced by measuring your usage against your limits, and the big idea behind reducing throttling is to set your GOMAXPROCS according to your CPU limit - this leads to OOMKilled for pods.

Resolves: #197 
