### PR TITLE
feat(alloy): enhance Alloy configuration with clustering

### DIFF
--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -220,12 +220,22 @@ data:
     prometheus.exporter.self "self" {}
 
     prometheus.remote_write "prometheus" {
+      wal {
+        max_keepalive_time = "30m"
+        min_keepalive_time = "15m"
+        truncate_frequency = "45m"
+      }
       endpoint {
         url = "http://prometheus-server/api/v1/write"
       }
     }
 
     prometheus.remote_write "mimir" {
+      wal {
+        max_keepalive_time = "30m"
+        min_keepalive_time = "15m"
+        truncate_frequency = "45m"
+      }
       endpoint {
         url = "http://mimir/api/v1/push"
       }

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -34,8 +34,11 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=$(POD_IP):12345
             - --server.http.ui-path-prefix=/
-            - --stability.level=experimental
+            - --stability.level=public-preview
             - --feature.community-components.enabled
+            - --cluster.enabled=true
+            - --cluster.name=$(HOSTNAME)
+            - --cluster.wait-for-size=1
           env:
             - name: ALLOY_DEPLOY_MODE
               value: "helm"
@@ -51,8 +54,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.cpu
             - name: GOMEMLIMIT
-              value: "768MiB"
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.memory
           ports:
             - name: metrics
               containerPort: 12345
@@ -91,18 +102,6 @@ spec:
               mountPath: /etc/alloy
             - name: tmp
               mountPath: /tmp/alloy
-        - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
-          args:
-            - --watched-dir=/etc/alloy
-            - --reload-url=http://localhost:12345/-/reload
-          volumeMounts:
-            - name: config
-              mountPath: /etc/alloy
-          resources:
-            requests:
-              cpu: 10m
-              memory: 50Mi
       dnsPolicy: ClusterFirst
       volumes:
         - name: config


### PR DESCRIPTION
This pull request introduces configuration improvements for the Alloy deployment, focusing on enhanced clustering support, resource management, and more robust WAL (Write-Ahead Log) handling for Prometheus remote write integrations. These changes improve Alloy's scalability, reliability, and resource utilization in Kubernetes environments.

**Clustering & Deployment Enhancements:**
* Enabled cluster mode for Alloy, setting cluster name to the pod's hostname and requiring a minimum cluster size of one. This prepares Alloy for distributed operation and easier scaling.

**Resource Management Improvements:**
* Updated `GOMAXPROCS` and `GOMEMLIMIT` environment variables to dynamically derive their values from the container’s CPU and memory limits, enabling better resource allocation and performance tuning.

**Prometheus Remote Write WAL Configuration:**
* Added WAL configuration (`max_keepalive_time`, `min_keepalive_time`, `truncate_frequency`) for both Prometheus and Mimir remote write endpoints, enhancing data durability and reducing potential data loss during outages.

**Stability Level Update:**
* Changed the stability level from `experimental` to `public-preview`, reflecting Alloy's maturity and readiness for broader usage.

Resolves: #200 