### PR TITLE
feat(tempo): enhance storage resource limits configuration

### DIFF
--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -26,6 +26,11 @@ data:
         local_blocks:
           filter_server_spans: true
           flush_to_storage: true
+        host_info:
+          host_identifiers:
+            - k8s.node.name
+            - host.id
+          metric_name: traces_host_info
         service_graphs:
           enable_client_server_prefix: true
           enable_virtual_node_label: true
@@ -36,13 +41,12 @@ data:
         path: /var/tempo/generator/traces
       storage:
         path: /var/tempo/generator/wal
-        wal:
-          truncate_frequency: 30m
         remote_write:
           - url: http://prometheus-server/api/v1/write
             send_exemplars: true
+            name: prometheus
           - url: http://mimir/api/v1/push
-            send_native_histograms: true
+            send_exemplars: true
             name: mimir
     distributor:
       max_attribute_bytes: 512
@@ -72,9 +76,6 @@ data:
       http_listen_port: 3100
     storage:
       trace:
-        # redis:
-        #   endpoint: redis.storage.svc
-        #   expiration: 2
         backend: local
         block:
           version: vParquet4

--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -36,6 +36,8 @@ data:
         path: /var/tempo/generator/traces
       storage:
         path: /var/tempo/generator/wal
+        wal:
+          truncate_frequency: 30m
         remote_write:
           - url: http://prometheus-server/api/v1/write
             send_exemplars: true

--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -24,12 +24,20 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=512
-        image: docker.io/grafana/tempo:2.8.1
+        image: docker.io/grafana/tempo:2.8.2
         imagePullPolicy: IfNotPresent
         name: tempo
         env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: '1'
+              resource: limits.cpu
         - name: GOMEMLIMIT
-          value: "768MiB"
+          valueFrom:
+            resourceFieldRef:
+              divisor: '1'
+              resource: limits.memory
         ports:
         - containerPort: 3100
           name: prom-metrics
@@ -85,7 +93,7 @@ spec:
             type: RuntimeDefault
           capabilities:
             drop:
-              - ALL
+            - ALL
       volumes:
         - name: tempo-storage
           emptyDir:

--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -24,10 +24,16 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=512
+        - -generator.instance-id=$(POD_IP)
+        - -log.level=warn
         image: docker.io/grafana/tempo:2.8.2
         imagePullPolicy: IfNotPresent
         name: tempo
         env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: GOMAXPROCS
           valueFrom:
             resourceFieldRef:


### PR DESCRIPTION
This pull request updates the configuration and deployment of the Tempo tracing service, focusing on improved resource management, storage configuration, and compatibility with external systems. The changes include an upgrade to the Tempo Docker image, enhanced environment variable management for dynamic resource allocation, and refinements to the storage and remote write settings.

**Deployment and Resource Management:**
* Upgraded the Tempo Docker image from `2.8.1` to `2.8.2`, ensuring the latest features and bug fixes are included.
* Added environment variables for `POD_IP`, `GOMAXPROCS`, and updated `GOMEMLIMIT` to dynamically use Kubernetes resource limits, improving resource allocation and container performance.
* Introduced new command-line arguments for instance identification and log level configuration, aiding in better logging and traceability.

**Storage and Trace Configuration:**
* Cleaned up the trace storage backend configuration by removing commented-out Redis settings, clarifying that local storage is used with Parquet block versioning.

**Remote Write Integration:**
* Enhanced remote write settings by specifying the `name` field for Prometheus and Mimir endpoints and ensuring both use `send_exemplars: true` for consistent trace exemplars export.