### PR TITLE
feat: update container images and enhance resource limits for multiple deployments

### DIFF
--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -26,7 +26,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.10.0
+          image: docker.io/grafana/alloy:v1.10.2
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
-          image: docker.io/grafana/beyla:2.5.2
+          image: docker.io/grafana/beyla:2.5.8
           imagePullPolicy: IfNotPresent
           ports:
           - name: metrics
@@ -42,8 +42,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.cpu
             - name: GOMEMLIMIT
-              value: "512MiB"
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.memory
           securityContext:
             runAsUser: 0
             privileged: true

--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -46,6 +46,17 @@ spec:
       - name: grafana
         image: docker.io/grafana/grafana:12.1.0
         imagePullPolicy: IfNotPresent
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: '1'
+              resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: '1'
+              resource: limits.memory
         ports:
         - containerPort: 3000
           name: http

--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -34,8 +34,17 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"
-            # - "-pattern-ingester.enabled=true"
-            # - "-tracing.profiling-enabled=true"
+          env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.cpu
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: '1'
+                  resource: limits.memory
           volumeMounts:
             - name: config
               mountPath: "/etc/loki"

--- a/deployment/promtail/daemonset.yml
+++ b/deployment/promtail/daemonset.yml
@@ -31,6 +31,16 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: GOMAXPROCS
+            valueFrom:
+              resourceFieldRef:
+                divisor: '1'
+                resource: limits.cpu
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                divisor: '1'
+                resource: limits.memory
           ports:
             - name: http-metrics
               containerPort: 3101

--- a/deployment/pyroscope/deployment.yml
+++ b/deployment/pyroscope/deployment.yml
@@ -41,6 +41,17 @@ spec:
           - "-config.file=/etc/pyroscope/config.yaml"
           - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
           - "-log.level=info"
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: '1'
+              resource: limits.cpu
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: '1'
+              resource: limits.memory
         ports:
         - name: http
           containerPort: 4040


### PR DESCRIPTION
## What
This PR updates container images to their latest versions and enhances resource management by adding environment variables for better Go runtime performance in multiple Grafana Loki on Kubernetes deployments.

## Why
- Keeping container images up to date ensures security patches, bug fixes, and new features are applied.
- Adding `GOMAXPROCS` and `GOMEMLIMIT` environment variables allows Go applications to better utilize allocated CPU and memory resources, improving performance, stability, and resource efficiency.

## Changes
- **Alloy**: Updated image from `docker.io/grafana/alloy:v1.10.0` to `docker.io/grafana/alloy:v1.10.2`
- **Beyla**: Updated image from `docker.io/grafana/beyla:2.5.2` to `docker.io/grafana/beyla:2.5.8`, added `GOMAXPROCS` and `GOMEMLIMIT` env vars using resourceFieldRef
- **Grafana**: Added `GOMAXPROCS` and `GOMEMLIMIT` env vars using resourceFieldRef
- **Loki**: Added `GOMAXPROCS` and `GOMEMLIMIT` env vars using resourceFieldRef
- **Promtail**: Added `GOMAXPROCS` and `GOMEMLIMIT` env vars using resourceFieldRef
- **Pyroscope**: Added `GOMAXPROCS` and `GOMEMLIMIT` env vars using resourceFieldRef

## Resources
- [Grafana Alloy releases](https://github.com/grafana/alloy/releases)
- [Grafana Beyla releases](https://github.com/grafana/beyla/releases)
- [Go runtime environment variables documentation](https://pkg.go.dev/runtime)