### PR TITLE
feat(alloy): update remote write durations, enhance OTelcol receiver and probes

### DIFF
--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -302,10 +302,14 @@ data:
 
     otelcol.processor.batch "beyla" {
       output {
-        logs    = [loki.write.loki.input]
+        logs    = [otelcol.exporter.loki.loki.input]
         metrics = [otelcol.exporter.prometheus.beyla.input]
         traces  = [otelcol.exporter.otlp.tempo.input]
       }
+    }
+
+    otelcol.exporter.loki "loki" {
+      forward_to = [loki.process.add_replay_label.receiver]
     }
 
     otelcol.exporter.prometheus "beyla" {

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -64,6 +64,8 @@ spec:
                 resourceFieldRef:
                   divisor: '1'
                   resource: limits.memory
+            - name: GOGC
+              value: "50"
           ports:
             - name: metrics
               containerPort: 12345
@@ -86,8 +88,19 @@ spec:
               path: /-/ready
               port: 12345
               scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 30
+            timeoutSeconds: 2
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
           securityContext:
             privileged: true
             readOnlyRootFilesystem: true


### PR DESCRIPTION
### What 🦾
- Updated Prometheus and Mimir remote write settings for WAL durations
- Improved OTelcol receiver for gRPC/HTTP endpoints with explicit IP binding and log support
- Enhanced DaemonSet readiness and liveness probes with more resilient parameters

### Why ❓
- Align with best practices for observability and data pipeline longevity
- Enable fine-grained binding for trace and metric receivers on the allocated Pod IP
- Increase robustness of Kubernetes deployments via more resilient health checks

### Changes ✨
- Adjusted `max_keepalive_time`, `min_keepalive_time`, and `truncate_frequency` in Prometheus and Mimir remote_write config
- OTelcol receiver bound to `sys.env("POD_IP")`, added log outputs
- Refined DaemonSet `initialDelaySeconds`, `timeoutSeconds`, `periodSeconds`, and `failureThreshold` for probes

### Resources 📚
- [Prometheus remote_write docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write)
- [Kubernetes Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

Resolves: #211