### PR TITLE
chore(alloy): consolidate discovery and relabeling

### DIFF
--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -29,6 +29,18 @@ data:
       }
     }
 
+    discovery.kubernetes "nodes" {
+      role = "node"
+    }
+
+    discovery.kubernetes "services" {
+      role = "service"
+    }
+
+    discovery.kubernetes "ingresses" {
+      role = "ingress"
+    }
+
     discovery.relabel "pod_logs" {
       targets = discovery.kubelet.pods.targets
       rule {
@@ -87,6 +99,14 @@ data:
       }
       rule {
         action = "labelmap"
+        regex = "__meta_kubernetes_node_address_(.+)"
+      }
+      rule {
+        action = "labelmap"
+        regex  = "__meta_kubernetes_node_label_(.+)"
+      }
+      rule {
+        action = "labelmap"
         regex  = "__meta_kubernetes_pod_label_(.+)"
       }
       rule {
@@ -115,18 +135,6 @@ data:
         action = "labeldrop"
         regex  = "pod_template_hash|controller_revision_hash|checksum_.*|pod_uid|instance|job"
       }
-    }
-
-    discovery.kubernetes "nodes" {
-    	role = "node"
-    }
-
-    discovery.kubernetes "services" {
-    	role = "service"
-    }
-
-    discovery.kubernetes "ingresses" {
-    	role = "ingress"
     }
 
     loki.write "loki" {
@@ -214,7 +222,6 @@ data:
 
     otelcol.processor.discovery "default" {
       targets = array.concat(discovery.kubelet.pods.targets, discovery.kubernetes.nodes.targets)
-
       output {
         traces = [otelcol.exporter.otlp.tempo.input]
       }


### PR DESCRIPTION
This pull request updates the Kubernetes resource discovery configuration in `deployment/alloy/cm.yml` to improve the flexibility and coverage of resource monitoring. The most important changes involve moving the discovery of nodes, services, and ingresses to an earlier section, enhancing relabeling rules to support node metadata, and updating how resource targets are combined for processing.

**Kubernetes resource discovery configuration:**

* Moved the definitions for `discovery.kubernetes` resources (`nodes`, `services`, and `ingresses`) to an earlier section in the configuration, ensuring these resources are discovered before relabeling and processing steps. [[1]](diffhunk://#diff-fb488f5f9e102d83eaa89eeabf80e9e6587435c070c62790d8c1836809b27a46R32-R43) [[2]](diffhunk://#diff-fb488f5f9e102d83eaa89eeabf80e9e6587435c070c62790d8c1836809b27a46L120-L131)

**Relabeling enhancements:**

* Added new relabeling rules to map node addresses and node labels, allowing for improved labeling and filtering of metrics based on node metadata.

**Processing updates:**

* Updated the `otelcol.processor.discovery` targets to use a concatenated array of pod and node targets, streamlining the input for trace processing.

Resolves: #221 