### PR TITLE
feat: add discovery of endpoints and endpointslices

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@
 I am assuming you are already familiar with [Grafana Stack](https://grafana.com/about/grafana-stack/).
 
 ## Prerequisites
-- Kubernetes Cluster >= v1.26
+- Kubernetes Cluster >= v1.28
 - Familiarity with Grafana Stack
+- Observability
 - ...
 - Profit?
 

--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -245,7 +245,7 @@ data:
         name = "rate-limit-ok"
         type = "rate_limiting"
         rate_limiting {
-          spans_per_second = 200
+          spans_per_second = 400
         }
       }
       output {
@@ -279,6 +279,9 @@ data:
     }
 
     otelcol.processor.batch "otel" {
+      timeout = "6s"
+      send_batch_size = 200
+      send_batch_max_size = 300
       output {
         logs    = [otelcol.exporter.loki.loki.input]
         metrics = [otelcol.exporter.prometheus.otel.input]


### PR DESCRIPTION
This pull request updates the Kubernetes and Alloy configuration to improve compatibility with newer Kubernetes versions and enhance observability and trace sampling. The main changes involve switching resource discovery from `ingresses` to `endpointslices`, updating relabeling rules, and introducing a rate-limiting processor for traces.

**Kubernetes Compatibility and Resource Discovery Updates:**

* Increased minimum required Kubernetes version from v1.26 to v1.28 in `README.md` and added observability as a prerequisite.
* Changed Alloy discovery to use `endpointslices` instead of `ingresses`, and updated all related target concatenations in `deployment/alloy/cm.yml`. [[1]](diffhunk://#diff-fb488f5f9e102d83eaa89eeabf80e9e6587435c070c62790d8c1836809b27a46L40-R41) [[2]](diffhunk://#diff-fb488f5f9e102d83eaa89eeabf80e9e6587435c070c62790d8c1836809b27a46R50-R57)

**Relabeling Rule Adjustments:**

* Updated relabeling rules to properly handle `endpointslice` and `ingress` labels, ensuring correct mapping for resource discovery.
* Added a new relabeling rule for Kubernetes node labels to improve metadata enrichment.

**Trace Sampling and Batch Processing Enhancements:**

* Introduced a new `otelcol.processor.tail_sampling` processor for rate-limiting and error sampling of traces, improving trace management and reducing noise.
* Configured batch processor with custom timeout and batch size settings to optimize trace export performance.

- **feat: add discovery for endpoints and endpointslices**
- **fix: discovery Kubernetes role endpoints**
- Resolves: #226 
