### PR TITLE
feat(grafana): update Grafana image to version 12.3.0

### DIFF
--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:12.2.1
+        image: docker.io/grafana/grafana:12.3.0
         imagePullPolicy: IfNotPresent
         env:
         - name: GOMAXPROCS


### PR DESCRIPTION
This pull request updates the Grafana deployment to use a newer version of the Grafana image.

* Upgraded the Grafana container image from `docker.io/grafana/grafana:12.2.1` to `docker.io/grafana/grafana:12.3.0` in the `deployment/grafana/deployment.yml` file.