### PR TITLE
feat(deps): upgrade images for alloy, beyla, loki, mimir, prometheus, and promtail to latest versions

### DIFF
--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -26,7 +26,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.11.3
+          image: docker.io/grafana/alloy:v1.12.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
-          image: docker.io/grafana/beyla:2.7.5
+          image: docker.io/grafana/beyla:2.8.1
           imagePullPolicy: IfNotPresent
           ports:
           - name: metrics

--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -30,7 +30,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.5.8
+          image: docker.io/grafana/loki:3.6.3
           imagePullPolicy: IfNotPresent
           args:
             - -target=all

--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -35,7 +35,7 @@ spec:
         - '-ingester.out-of-order-time-window=15m'
         - '-log.format=json'
         - '-log.level=warn'
-        image: grafana/mimir:2.17.2
+        image: docker.io/grafana/mimir:3.0.1
         imagePullPolicy: IfNotPresent
         name: mimir
         env:

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v3.7.3
+          image: docker.io/prom/prometheus:v3.8.0
           imagePullPolicy: IfNotPresent
           env:
             - name: GOMAXPROCS

--- a/deployment/promtail/daemonset.yml
+++ b/deployment/promtail/daemonset.yml
@@ -24,7 +24,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:3.5.8
+          image: docker.io/grafana/promtail:3.6.3
           imagePullPolicy: IfNotPresent
           env:
           - name: HOSTNAME


### PR DESCRIPTION
This pull request updates several monitoring and observability components to their latest stable versions in the deployment manifests. These upgrades help ensure improved performance, security, and access to new features. The most important changes are grouped below by component:

**Grafana Stack Upgrades:**

* Upgraded `alloy` container image to version `v1.12.0` in `deployment/alloy/daemonset.yml`.
* Upgraded `beyla` container image to version `2.8.1` in `deployment/beyla/daemonset.yml`.
* Upgraded `loki` container image to version `3.6.3` in `deployment/loki/statefulset.yml`.
* Upgraded `mimir` container image to version `3.0.1` and switched to the `docker.io/grafana/mimir` repository in `deployment/mimir/statefulset.yml`.
* Upgraded `promtail` container image to version `3.6.3` in `deployment/promtail/daemonset.yml`.

**Prometheus Upgrade:**

* Upgraded `prometheus` container image to version `v3.8.0` in `deployment/prometheus/deployment.yml`.