### PR TITLE
fix(loki): remove ui advertise address argument from Loki StatefulSet

### DIFF
--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -34,7 +34,6 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - -target=all
-            - "-ui.advertise-addr=$(POD_IP)"
             - "-config.file=/etc/loki/loki.yaml"
           env:
             - name: GOMAXPROCS


### PR DESCRIPTION
This pull request makes a minor change to the `deployment/loki/statefulset.yml` file, specifically removing the `-ui.advertise-addr=$(POD_IP)` argument from the Loki container's startup arguments. This simplifies the container configuration and may resolve issues related to UI address advertisement.