### PR TITLE
chore(alloy): minor patch bump

### DIFF
--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -26,7 +26,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.12.0
+          image: docker.io/grafana/alloy:v1.12.2
           imagePullPolicy: IfNotPresent
           args:
             - run


### PR DESCRIPTION
This pull request makes a minor update to the Alloy deployment configuration, upgrading the container image to a newer version.

- Updated the Alloy container image in `deployment/alloy/daemonset.yml` from version `v1.12.0` to `v1.12.2` to ensure the deployment uses the latest available features and fixes.