### PR TITLE
chore(mimir): update image version to 3.0.2

### DIFF
--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -35,7 +35,7 @@ spec:
         - '-ingester.out-of-order-time-window=15m'
         - '-log.format=json'
         - '-log.level=warn'
-        image: docker.io/grafana/mimir:3.0.1
+        image: docker.io/grafana/mimir:3.0.2
         imagePullPolicy: IfNotPresent
         name: mimir
         env:


### PR DESCRIPTION
This pull request updates the `mimir` container image to a newer version in the `statefulset.yml` deployment configuration.

* Upgraded the `grafana/mimir` image from version `3.0.1` to `3.0.2` in `deployment/mimir/statefulset.yml` to include the latest fixes and improvements.

- Resolves: #240 