### PR TITLE
chore(grafana): increase size limit of grafana-storage 

### DIFF
--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -124,4 +124,4 @@ spec:
             name: grafana-ini
         - name: grafana-storage
           emptyDir:
-            sizeLimit: "2Gi"
+            sizeLimit: "4Gi"


### PR DESCRIPTION
This pull request makes a small configuration update to the Grafana deployment, increasing the storage size limit for the `grafana-storage` volume from 2Gi to 4Gi.