### PR TITLE
chore(version-bump): services version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,16 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@v1.13.0
+        with:
+          kubectl_version: v1.33.7 # Ensure compatibility with the latest APIs
+          node_image: kindest/node:v1.33.7 # Match node version with kubectl for consistency
       - name: Check out repository code
         uses: actions/checkout@v6
       - name: Run K8s test
         run: |
           kubectl cluster-info
+          kubectl create ns monitoring
           kubectl apply -k deployment/
           kubectl get all -A
 

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -26,7 +26,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.12.2
+          image: docker.io/grafana/alloy:v1.15.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
-          image: docker.io/grafana/beyla:2.8.1
+          image: docker.io/grafana/beyla:3.7.1
           imagePullPolicy: IfNotPresent
           ports:
           - name: metrics

--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:12.3.0
+        image: docker.io/grafana/grafana:12.4.2
         imagePullPolicy: IfNotPresent
         env:
         - name: GOMAXPROCS

--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -35,7 +35,7 @@ spec:
         - '-ingester.out-of-order-time-window=15m'
         - '-log.format=json'
         - '-log.level=warn'
-        image: docker.io/grafana/mimir:3.0.2
+        image: docker.io/grafana/mimir:3.0.5
         imagePullPolicy: IfNotPresent
         name: mimir
         env:

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v3.8.0
+          image: docker.io/prom/prometheus:v3.11.0
           imagePullPolicy: IfNotPresent
           env:
             - name: GOMAXPROCS

--- a/deployment/pyroscope/deployment.yml
+++ b/deployment/pyroscope/deployment.yml
@@ -30,7 +30,7 @@ spec:
         runAsUser: 10001
       containers:
       - name: pyroscope
-        image: docker.io/grafana/pyroscope:1.17.0
+        image: docker.io/grafana/pyroscope:1.19.1
         imagePullPolicy: IfNotPresent
         args:
           - "-target=all"

--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -27,7 +27,7 @@ spec:
         - -generator.instance-id=$(POD_IP)
         - -log.level=warn
         - -config.expand-env=true
-        image: docker.io/grafana/tempo:2.9.0
+        image: docker.io/grafana/tempo:2.10.3
         imagePullPolicy: IfNotPresent
         name: tempo
         env:


### PR DESCRIPTION
This pull request updates the container images for several core observability components to their latest stable versions. These changes ensure that the deployment uses the most recent features, performance improvements, and security patches available for each service.

**Container image version upgrades:**

*Grafana Stack:*
- Upgraded `grafana` image from `12.3.0` to `12.4.2` in `deployment/grafana/deployment.yml`
- Upgraded `mimir` image from `3.0.2` to `3.0.5` in `deployment/mimir/statefulset.yml`
- Upgraded `tempo` image from `2.9.0` to `2.10.3` in `deployment/tempo/statefulset.yml`
- Upgraded `pyroscope` image from `1.17.0` to `1.19.1` in `deployment/pyroscope/deployment.yml`

*Prometheus and Related Agents:*
- Upgraded `prometheus` image from `v3.8.0` to `v3.11.0` in `deployment/prometheus/deployment.yml`
- Upgraded `alloy` image from `v1.12.2` to `v1.15.0` in `deployment/alloy/daemonset.yml`
- Upgraded `beyla` image from `2.8.1` to `3.7.1` in `deployment/beyla/daemonset.yml`

- **chore(alloy): update image version to v1.15.0**
- **chore(beyla): update image version to 3.7.1**
- **chore(grafana): update image version to 12.4.2**
- **chore(mimir): update image version to 3.0.5**
- **chore(prometheus): update image version to v3.11.0**
- **chore(pyroscope): update image version to 1.19.1**
- **chore(tempo): update image version to 2.10.3**
