### PR TITLE
chore(deps): bump Grafana and Prometheus stack versions

### DIFF
--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -85,6 +85,11 @@ data:
         action        = "replace"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]
+        regex         = "false"
+        action        = "drop"
+      }
+      rule {
         source_labels = ["__address__"]
         regex        = ".+"
         action       = "keep"

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -26,7 +26,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.15.0
+          image: docker.io/grafana/alloy:v1.16.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
-          image: docker.io/grafana/beyla:3.7.1
+          image: docker.io/grafana/beyla:3.14.0
           imagePullPolicy: IfNotPresent
           ports:
           - name: metrics

--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:12.4.2
+        image: docker.io/grafana/grafana:13.0.1
         imagePullPolicy: IfNotPresent
         env:
         - name: GOMAXPROCS

--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -30,7 +30,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.6.3
+          image: docker.io/grafana/loki:3.7.2
           imagePullPolicy: IfNotPresent
           args:
             - -target=all

--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -35,7 +35,7 @@ spec:
         - '-ingester.out-of-order-time-window=15m'
         - '-log.format=json'
         - '-log.level=warn'
-        image: docker.io/grafana/mimir:3.0.5
+        image: docker.io/grafana/mimir:3.0.6
         imagePullPolicy: IfNotPresent
         name: mimir
         env:

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v3.11.0
+          image: docker.io/prom/prometheus:v3.11.3
           imagePullPolicy: IfNotPresent
           env:
             - name: GOMAXPROCS

--- a/deployment/promtail/daemonset.yml
+++ b/deployment/promtail/daemonset.yml
@@ -24,7 +24,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:3.6.3
+          image: docker.io/grafana/promtail:3.7.2
           imagePullPolicy: IfNotPresent
           env:
           - name: HOSTNAME

--- a/deployment/pyroscope/deployment.yml
+++ b/deployment/pyroscope/deployment.yml
@@ -30,7 +30,7 @@ spec:
         runAsUser: 10001
       containers:
       - name: pyroscope
-        image: docker.io/grafana/pyroscope:1.19.1
+        image: docker.io/grafana/pyroscope:2.10.5
         imagePullPolicy: IfNotPresent
         args:
           - "-target=all"


### PR DESCRIPTION
## Summary

Bumps container image versions across the observability stack:

| Service | Old | New |
|---------|-----|-----|
| Alloy | v1.15.0 | v1.16.1 |
| Beyla | 3.7.1 | 3.14.0 |
| Grafana | 12.4.2 | 13.0.1 |
| Loki | 3.6.3 | 3.7.2 |
| Mimir | 3.0.5 | 3.0.6 |
| Prometheus | v3.11.0 | v3.11.3 |
| Promtail | 3.6.3 | 3.7.2 |
| Pyroscope | 1.19.1 | 2.10.5 |

Fixes Alloy scraping Redis directly on port 6379. Alloy was discovering all pods via kubelet and sending HTTP scrape requests to everything, including Redis - which has no metrics endpoint and logs it as a security attack. Added an opt-out relabeling rule so pods annotated with `prometheus.io/scrape: "false"` are dropped before scraping. No change to default scraping behaviour.

To exclude Redis, add to the pod/deployment template:
```yaml
annotations:
  prometheus.io/scrape: "false"
```

## Test plan

- [x] Deploy to test cluster
- [x] Verify all pods start cleanly
- [x] Check Grafana dashboards load correctly
- [x] Confirm log ingestion via Promtail/Loki
- [x] Validate metrics flow through Prometheus/Mimir/Alloy
- [ ] Confirm Redis security attack errors stop after annotating Redis pods