### PR TITLE
fix(alloy,tempo,grafana): config review, bug fixes, and service-graph repair

### DIFF
--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -237,8 +237,8 @@ data:
       }
       output {
         traces = [
-          otelcol.processor.batch.otel.input,
           otelcol.connector.servicegraph.tempo.input,
+          otelcol.processor.batch.otel.input,
         ]
       }
     }

--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -51,7 +51,7 @@ data:
       rule {
         action = "replace"
         regex = "(.*)@(.*)"
-        replacement = "ebpf/${1}/${2}"
+        replacement = "k8s/${1}/${2}"
         separator = "@"
         source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
         target_label = "service_name"
@@ -64,24 +64,10 @@ data:
         action        = "replace"
       }
       rule {
-        source_labels = ["__meta_kubernetes_endpointslice_name"]
-        regex         = ".+"
-        target_label  = "source"
-        replacement   = "endpointslices"
-        action        = "replace"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_container_name"]
         regex         = ".+"
         target_label  = "source"
         replacement   = "kubelet_pods"
-        action        = "replace"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_ingress_name"]
-        regex         = ".+"
-        target_label  = "source"
-        replacement   = "ingresses"
         action        = "replace"
       }
       rule {
@@ -111,14 +97,6 @@ data:
         regex  = "__meta_kubernetes_service_label_(.+)"
       }
       rule {
-        action = "labelmap"
-        regex  = "__meta_kubernetes_endpointslice_label_(.+)"
-      }
-      rule {
-        action = "labelmap"
-        regex  = "__meta_kubernetes_ingress_label_(.+)"
-      }
-      rule {
         action = "replace"
         source_labels = ["__meta_kubernetes_namespace"]
         target_label = "namespace"
@@ -135,22 +113,26 @@ data:
     }
 
     loki.write "loki" {
+      max_streams = 1000
       endpoint {
-        url = "http://loki:3100/loki/api/v1/push"
+        url                 = "http://loki:3100/loki/api/v1/push"
+        retry_on_http_429   = true
+        min_backoff_period  = "500ms"
+        max_backoff_period  = "5m"
+        max_backoff_retries = 10
       }
     }
 
     loki.source.kubernetes "pods" {
       targets    = discovery.relabel.pod_logs.output
-      forward_to = [loki.process.add_replay_label.receiver]
+      forward_to = [loki.process.pod_logs_filter.receiver]
     }
 
-    loki.process "add_replay_label" {
+    loki.process "pod_logs_filter" {
       stage.drop {
-        older_than = "1h"
+        older_than          = "1h"
         drop_counter_reason = "line_too_old"
       }
-      // stage.logfmt {}
       forward_to = [loki.write.loki.receiver]
     }
 
@@ -174,29 +156,29 @@ data:
     }
 
     prometheus.remote_write "prometheus" {
-       wal {
-          max_keepalive_time = "10m"
-          min_keepalive_time = "5m"
-          truncate_frequency = "5m"
-        }
-        endpoint {
-          url = "http://prometheus-server/api/v1/write"
-          remote_timeout = "10s"
-          send_exemplars = true
-          send_native_histograms = true
-        }
+      wal {
+        max_keepalive_time = "8h"
+        min_keepalive_time = "5m"
+        truncate_frequency = "1h"
+      }
+      endpoint {
+        url                    = "http://prometheus-server/api/v1/write"
+        remote_timeout         = "10s"
+        send_exemplars         = true
+        send_native_histograms = true
+      }
     }
 
     prometheus.remote_write "mimir" {
       wal {
-          max_keepalive_time = "10m"
-          min_keepalive_time = "5m"
-          truncate_frequency = "5m"
+        max_keepalive_time = "8h"
+        min_keepalive_time = "5m"
+        truncate_frequency = "1h"
       }
       endpoint {
-        url = "http://mimir/api/v1/push"
-        remote_timeout = "10s"
-        send_exemplars = true
+        url                    = "http://mimir/api/v1/push"
+        remote_timeout         = "10s"
+        send_exemplars         = true
         send_native_histograms = true
       }
     }
@@ -204,21 +186,38 @@ data:
     prometheus.scrape "default" {
       targets    = discovery.relabel.all_targets_with_address.output
       forward_to = [prometheus.remote_write.prometheus.receiver, prometheus.remote_write.mimir.receiver]
-      extra_metrics = false
     }
 
     otelcol.exporter.otlp "tempo" {
       client {
         endpoint = "tempo:4317"
         tls {
-          insecure             = true
-          insecure_skip_verify = true
+          insecure = true
         }
       }
     }
 
     otelcol.processor.k8sattributes "default" {
-      passthrough = false 
+      pod_association {
+        source {
+          from = "connection"
+        }
+      }
+      pod_association {
+        source {
+          from  = "resource_attribute"
+          name  = "k8s.pod.ip"
+        }
+      }
+      extract {
+        metadata = [
+          "k8s.namespace.name",
+          "k8s.node.name",
+          "k8s.pod.name",
+          "k8s.pod.uid",
+          "k8s.deployment.name",
+        ]
+      }
       output {
         traces = [
           otelcol.processor.tail_sampling.rate_limiter.input,
@@ -250,7 +249,7 @@ data:
     }
 
     otelcol.connector.servicegraph "tempo" {
-      dimensions = ["http.method", "http.target"]
+      dimensions = ["http.method", "http.request.method", "http.target", "url.path"]
       output {
         metrics = [otelcol.exporter.prometheus.otel.input]
       }
@@ -283,7 +282,7 @@ data:
     }
 
     otelcol.exporter.loki "loki" {
-      forward_to = [loki.process.add_replay_label.receiver]
+      forward_to = [loki.write.loki.receiver]
     }
 
     otelcol.exporter.prometheus "otel" {

--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -81,12 +81,22 @@ data:
         action       = "keep"
       }
       rule {
-        action = "labelmap"
-        regex = "__meta_kubernetes_node_address_(.+)"
+        action        = "replace"
+        source_labels = ["__meta_kubernetes_node_label_kubernetes_io_hostname"]
+        regex         = "(.+)"
+        target_label  = "node_hostname"
       }
       rule {
-        action = "labelmap"
-        regex  = "__meta_kubernetes_node_label_(.+)"
+        action        = "replace"
+        source_labels = ["__meta_kubernetes_node_label_topology_kubernetes_io_zone"]
+        regex         = "(.+)"
+        target_label  = "zone"
+      }
+      rule {
+        action        = "replace"
+        source_labels = ["__meta_kubernetes_node_label_topology_kubernetes_io_region"]
+        regex         = "(.+)"
+        target_label  = "region"
       }
       rule {
         action = "labelmap"
@@ -137,21 +147,6 @@ data:
     }
 
     loki.source.kubernetes_events "cluster" {
-      forward_to = [loki.write.loki.receiver]
-    }
-
-    loki.source.syslog "local" {
-      listener {
-        address  = "0.0.0.0:51893"
-        labels   = { component = "loki.source.syslog", protocol = "tcp" }
-      }
-
-      listener {
-        address  = "0.0.0.0:51898"
-        protocol = "udp"
-        labels   = { component = "loki.source.syslog", protocol = "udp"}
-      }
-
       forward_to = [loki.write.loki.receiver]
     }
 

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -81,12 +81,6 @@ spec:
             - name: otlp-http
               containerPort: 4318
               protocol: TCP
-            - name: syslog-tcp
-              containerPort: 51893
-              protocol: TCP
-            - name: syslog-udp
-              containerPort: 51898
-              protocol: UDP
           resources:
             requests:
               cpu: 50m

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -21,12 +21,13 @@ spec:
         filter.by.port.name: "true"
       labels:
         app.kubernetes.io/name: alloy
+        cluster: kubernetes
     spec:
       serviceAccountName: alloy
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.1
+          image: docker.io/grafana/alloy:v1.16.2
           imagePullPolicy: IfNotPresent
           args:
             - run
@@ -37,11 +38,15 @@ spec:
             - --stability.level=public-preview
             - --feature.community-components.enabled
             - --cluster.enabled=true
-            - --cluster.name=$(HOSTNAME)
+            - --cluster.name=$(CLUSTER_NAME)
             - --cluster.wait-for-size=1
           env:
             - name: ALLOY_DEPLOY_MODE
               value: "helm"
+            - name: CLUSTER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['cluster']
             - name: HOSTNAME
               valueFrom:
                 fieldRef:
@@ -76,6 +81,12 @@ spec:
             - name: otlp-http
               containerPort: 4318
               protocol: TCP
+            - name: syslog-tcp
+              containerPort: 51893
+              protocol: TCP
+            - name: syslog-udp
+              containerPort: 51898
+              protocol: UDP
           resources:
             requests:
               cpu: 50m

--- a/deployment/alloy/service.yml
+++ b/deployment/alloy/service.yml
@@ -23,11 +23,3 @@ spec:
       port: 4318
       protocol: TCP
       targetPort: 4318
-    - name: syslog-tcp
-      port: 51893
-      targetPort: 51893
-      protocol: TCP
-    - name: syslog-udp
-      port: 51898
-      targetPort: 51898
-      protocol: UDP

--- a/deployment/alloy/service.yml
+++ b/deployment/alloy/service.yml
@@ -23,3 +23,11 @@ spec:
       port: 4318
       protocol: TCP
       targetPort: 4318
+    - name: syslog-tcp
+      port: 51893
+      targetPort: 51893
+      protocol: TCP
+    - name: syslog-udp
+      port: 51898
+      targetPort: 51898
+      protocol: UDP

--- a/deployment/grafana/cm.yml
+++ b/deployment/grafana/cm.yml
@@ -30,6 +30,7 @@ data:
     apiVersion: 1
     datasources:
     - name: Mimir
+      uid: Mimir
       type: prometheus
       access: proxy
       editable: true
@@ -46,6 +47,7 @@ data:
     apiVersion: 1
     datasources:
     - name: Prometheus
+      uid: Prometheus
       type: prometheus
       access: proxy
       editable: true
@@ -61,6 +63,7 @@ data:
     apiVersion: 1
     datasources:
     - name: Pyroscope
+      uid: Pyroscope
       type: grafana-pyroscope-datasource
       access: proxy
       editable: true
@@ -71,6 +74,7 @@ data:
     apiVersion: 1
     datasources:
     - name: Loki
+      uid: Loki
       type: loki
       access: proxy
       editable: true
@@ -86,6 +90,7 @@ data:
     apiVersion: 1
     datasources:
     - name: Tempo
+      uid: Tempo
       type: tempo
       access: proxy
       editable: true

--- a/deployment/mimir/cm.yml
+++ b/deployment/mimir/cm.yml
@@ -56,6 +56,7 @@ data:
       compactor_blocks_retention_period: 15d
       enabled_promql_experimental_functions: all
       enabled_promql_extended_range_selectors: all
+      max_global_series_per_user: 500000
       out_of_order_time_window: 15m
 
     ruler_storage:

--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -21,10 +21,30 @@ data:
         - '::'
       abort_if_cluster_join_fails: false
     metrics_generator:
+      metrics_ingestion_time_range_slack: 60s
       ring:
         kvstore:
           store: memberlist
       processor:
+        service_graphs:
+          wait: 60s
+          max_items: 10000
+          enable_client_server_prefix: true
+          enable_virtual_node_label: true
+          enable_messaging_system_latency_histogram: true
+          peer_attributes:
+            - peer.service
+            - server.address
+            - net.peer.name
+            - db.name
+            - db.system
+            - network.peer.address
+          dimensions:
+            - http.method
+            - http.request.method
+            - http.target
+            - url.path
+
         local_blocks:
           filter_server_spans: true
           flush_to_storage: true
@@ -33,12 +53,6 @@ data:
             - k8s.node.name
             - host.id
           metric_name: traces_host_info
-        service_graphs:
-          wait: 10s
-          max_items: 10000
-          enable_client_server_prefix: true
-          enable_virtual_node_label: true
-          enable_messaging_system_latency_histogram: true
         span_metrics:
           enable_target_info: true
       traces_storage:
@@ -46,14 +60,14 @@ data:
       storage:
         path: /var/tempo/generator/wal
         remote_write:
-          - url: http://prometheus-server/api/v1/write
-            send_exemplars: true
-            name: prometheus
+          # - url: http://prometheus-server/api/v1/write
+          #   send_exemplars: true
+          #   name: prometheus
           - url: http://mimir/api/v1/push
             send_exemplars: true
             name: mimir
     distributor:
-      max_attribute_bytes: 512
+      max_attribute_bytes: 2048
       receivers:
         jaeger:
           protocols:
@@ -87,20 +101,15 @@ data:
         local:
           path: /var/tempo/traces
         wal:
-          search_encoding: snappy
           path: /var/tempo/wal
     querier:
       max_concurrent_queries: 20
       frontend_worker:
-        frontend_address: 0.0.0.0:9095
-    query_frontend: {}
+        frontend_address: ${POD_IP}:9095
     overrides:
       defaults:
         ingestion:
           max_traces_per_user: 0
         metrics_generator:
-          processors: [service-graphs, span-metrics, local-blocks]
+          processors: [service-graphs, span-metrics, local-blocks, host-info]
           generate_native_histograms: both
-      user_configurable_overrides:
-        api:
-          check_for_conflicting_runtime_overrides: true

--- a/deployment/tempo/headless-service.yml
+++ b/deployment/tempo/headless-service.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo-headless
+  labels:
+    app.kubernetes.io/name: tempo
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: tempo

--- a/deployment/tempo/kustomization.yml
+++ b/deployment/tempo/kustomization.yml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
 - account.yml
 - cm.yml
+- headless-service.yml
 - service.yml
 - statefulset.yml

--- a/deployment/tempo/service.yml
+++ b/deployment/tempo/service.yml
@@ -30,14 +30,6 @@ spec:
     port: 9411
     protocol: TCP
     targetPort: 9411
-  - name: tempo-otlp-legacy
-    port: 55680
-    protocol: TCP
-    targetPort: 55680
-  - name: tempo-otlp-http-legacy
-    port: 55681
-    protocol: TCP
-    targetPort: 4318
   - name: grpc-tempo-otlp
     port: 4317
     protocol: TCP
@@ -46,9 +38,5 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
-  - name: tempo-opencensus
-    port: 55678
-    protocol: TCP
-    targetPort: 55678
   selector:
     app.kubernetes.io/name: tempo

--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -23,7 +23,6 @@ spec:
       containers:
       - args:
         - -config.file=/conf/tempo.yaml
-        - -mem-ballast-size-mbs=512
         - -generator.instance-id=$(POD_IP)
         - -log.level=warn
         - -config.expand-env=true
@@ -60,16 +59,10 @@ spec:
           name: jaeger-grpc
         - containerPort: 9411
           name: zipkin
-        - containerPort: 55680
-          name: otlp-legacy
         - containerPort: 4317
           name: otlp-grpc
-        - containerPort: 55681
-          name: otlp-httplegacy
         - containerPort: 4318
           name: otlp-http
-        - containerPort: 55678
-          name: opencensus
         resources:
           limits:
             cpu: 100m

--- a/docs/alloy.md
+++ b/docs/alloy.md
@@ -6,8 +6,9 @@ This stack uses Alloy in place of Promtail. The Promtail directory is still in t
 
 ## What it runs
 
-- DaemonSet, image `docker.io/grafana/alloy:v1.16.1`.
-- Args: `run /etc/alloy/config.alloy --storage.path=/tmp/alloy --cluster.enabled=true --cluster.name=$(HOSTNAME) --cluster.wait-for-size=1 --feature.community-components.enabled --stability.level=public-preview`.
+- DaemonSet, image `docker.io/grafana/alloy:v1.16.2`.
+- Args: `run /etc/alloy/config.alloy --storage.path=/tmp/alloy --server.http.listen-addr=$(POD_IP):12345 --stability.level=public-preview --feature.community-components.enabled --cluster.enabled=true --cluster.name=$(CLUSTER_NAME) --cluster.wait-for-size=1`.
+- `CLUSTER_NAME` is read from the pod label `cluster` via the downward API, so it's set in the DaemonSet pod template rather than hardcoded in the args.
 - Ports: 12345 (HTTP UI and self metrics), 4317 (OTLP gRPC), 4318 (OTLP HTTP).
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 896Mi.
 - Storage: 1 Gi emptyDir at `/tmp/alloy` for remote_write WAL buffers.
@@ -26,7 +27,7 @@ loki.write "loki" {
 }
 ```
 
-Three log sources feed that writer: pod logs (`loki.source.kubernetes "pods"`, filtered to drop anything older than 1 hour), cluster events (`loki.source.kubernetes_events "cluster"`) and syslog on TCP `:51893` / UDP `:51898`.
+Two log sources feed that writer: pod logs (`loki.source.kubernetes "pods"`, filtered to drop anything older than 1 hour) and cluster events (`loki.source.kubernetes_events "cluster"`).
 
 Metrics fan out to both Prometheus and Mimir, with exemplars and native histograms on each:
 
@@ -52,7 +53,7 @@ prometheus.remote_write "mimir" {
 
 A single `prometheus.scrape "default"` block walks kubelet pod targets, nodes and services and forwards to both writers. Targets with `prometheus.io/scrape: "false"` get dropped during relabel.
 
-Traces come in on OTLP and leave on OTLP, with K8s metadata, tail sampling and a service-graph connector in the middle:
+Traces come in on OTLP, get K8s metadata attached, pass through tail sampling, and split: one copy goes to Tempo, the other feeds the service-graph connector:
 
 ```river
 otelcol.receiver.otlp "otel" {
@@ -73,18 +74,22 @@ otelcol.processor.tail_sampling "rate_limiter" {
   }
 }
 
+otelcol.connector.servicegraph "tempo" {
+  dimensions = ["http.method", "http.request.method", "http.target", "url.path"]
+  output {
+    metrics = [otelcol.exporter.prometheus.otel.input]
+  }
+}
+
 otelcol.exporter.otlp "tempo" {
   client {
     endpoint = "tempo:4317"
-    tls {
-      insecure             = true
-      insecure_skip_verify = true
-    }
+    tls { insecure = true }
   }
 }
 ```
 
-Errored spans are always sampled, everything else is capped at 400 spans/s. The service-graph connector turns spans into metrics that go back through the Prometheus and Mimir writers.
+Errored spans are always sampled, everything else is capped at 400 spans/s. The service-graph connector emits `traces_service_graph_*` metrics for span pairs it sees on the local node.
 
 Batch settings: 6 second timeout, 200 spans per batch, 300 max.
 
@@ -92,7 +97,6 @@ Batch settings: 6 second timeout, 200 spans per batch, 300 max.
 
 - Applications send OTLP logs, metrics and traces to the local Alloy on the node, port 4317 (gRPC) or 4318 (HTTP).
 - The kubelet at `https://$NODE_IP:10250` is the source for pod targets and pod logs.
-- Syslog clients can ship to TCP `:51893` or UDP `:51898`.
 
 ## Outputs
 

--- a/docs/tempo.md
+++ b/docs/tempo.md
@@ -2,16 +2,17 @@
 
 Tempo is the traces backend. Single binary (`target: all`), filesystem storage, single replica, multi-protocol ingest. Config lives in [`deployment/tempo/cm.yml`](../deployment/tempo/cm.yml).
 
-Beyond storing spans, it runs a `metrics_generator` that converts spans into RED metrics and service-graph metrics, then writes them to both Prometheus and Mimir.
+Beyond storing spans, it runs a `metrics_generator` that converts spans into RED metrics and service-graph metrics, then writes them to Mimir.
 
 ## What it runs
 
 - StatefulSet, single replica, image `docker.io/grafana/tempo:2.10.3`.
-- Args: `-target=all -config.file=/conf/tempo.yaml -mem-ballast-size-mbs=512 -generator.instance-id=$(POD_IP)`.
-- Ports: 3100 (HTTP query), 9095 (gRPC), 4317 (OTLP gRPC), 4318 (OTLP HTTP), 14250 (Jaeger gRPC), 14268 (Jaeger Thrift HTTP), 6831 / 6832 (Jaeger Thrift UDP), 9411 (Zipkin), 55678 (OpenCensus).
+- Args: `-config.file=/conf/tempo.yaml -config.expand-env=true -generator.instance-id=$(POD_IP) -log.level=warn`.
+- Ports: 3100 (HTTP query), 9095 (gRPC), 4317 (OTLP gRPC), 4318 (OTLP HTTP), 14250 (Jaeger gRPC), 14268 (Jaeger Thrift HTTP), 6831 / 6832 (Jaeger Thrift UDP), 9411 (Zipkin).
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 896Mi.
-- Storage: single 10 Gi emptyDir, split across `/var/tempo/wal`, `/var/tempo/traces`, `/var/tempo/generator/wal`, `/var/tempo/generator/traces` via subPaths.
+- Storage: single 10 Gi emptyDir split across `/var/tempo/wal`, `/var/tempo/traces`, `/var/tempo/generator/wal`, `/var/tempo/generator/traces` via subPaths.
 - Security: read-only root filesystem, all caps dropped, no privilege escalation.
+- A headless service (`tempo-headless`) exists alongside the ClusterIP service to satisfy the StatefulSet governing service requirement.
 
 ## Configuration
 
@@ -24,11 +25,11 @@ usage_report:
   reporting_enabled: false
 ```
 
-All ingest receivers in one block:
+All ingest receivers in one block. `max_attribute_bytes` is set to the Tempo default — anything lower silently truncates attribute values:
 
 ```yaml
 distributor:
-  max_attribute_bytes: 512
+  max_attribute_bytes: 2048
   receivers:
     jaeger:
       protocols:
@@ -54,7 +55,6 @@ storage:
     local:
       path: /var/tempo/traces
     wal:
-      search_encoding: snappy
       path: /var/tempo/wal
 ```
 
@@ -69,28 +69,37 @@ compactor:
     compaction_window: 2h
 ```
 
-Metrics-generator ring rides on memberlist, processors enabled in `overrides.defaults`:
+Metrics-generator ring rides on memberlist, four processors enabled:
 
 ```yaml
 overrides:
   defaults:
     metrics_generator:
-      processors: [service-graphs, span-metrics, local-blocks]
+      processors: [service-graphs, span-metrics, local-blocks, host-info]
       generate_native_histograms: both
 ```
 
-The generator writes those metrics to both Prometheus and Mimir:
+`host-info` emits a `traces_host_info` gauge keyed on `k8s.node.name` and `host.id`. `service-graphs` is tuned with a 60s wait to allow time for cross-node span pairs that arrive via tail sampling, plus peer_attributes and dimensions for richer label coverage. The generator writes metrics to Mimir:
 
 ```yaml
 metrics_generator:
   storage:
     remote_write:
-      - url: http://prometheus-server/api/v1/write
-        send_exemplars: true
-        name: prometheus
+      # - url: http://prometheus-server/api/v1/write
+      #   send_exemplars: true
+      #   name: prometheus
       - url: http://mimir/api/v1/push
         send_exemplars: true
         name: mimir
+```
+
+The querier connects to the co-located frontend using the pod IP, injected at startup via `-config.expand-env=true`:
+
+```yaml
+querier:
+  max_concurrent_queries: 20
+  frontend_worker:
+    frontend_address: ${POD_IP}:9095
 ```
 
 ## Inputs
@@ -102,14 +111,13 @@ otelcol.exporter.otlp "tempo" {
   client {
     endpoint = "tempo:4317"
     tls {
-      insecure             = true
-      insecure_skip_verify = true
+      insecure = true
     }
   }
 }
 ```
 
-The other receivers (Jaeger, Zipkin, OpenCensus) are available but nothing in this repo writes to them.
+The Jaeger and Zipkin receivers are available for services that instrument with those SDKs directly.
 
 ## Outputs
 


### PR DESCRIPTION
Config review across Alloy, Tempo, and Grafana. Validated with `alloy validate --stability.level=public-preview` and `tempo -config.verify=true` inside Docker at the pod's resource limits (100m CPU / 896Mi RAM).

**Alloy**

The `otelcol.connector.servicegraph` block was removed in a previous pass assuming Tempo's `metrics_generator` would take over. That doesn't work: Alloy runs as a DaemonSet so each instance only sees node-local spans. Cross-node span pairs never made it to Tempo's pairing window. Connector is back.

**Tempo**

Several config bugs fixed:

- `host-info` processor was configured in `metrics_generator.processor` but not listed in `overrides.defaults.metrics_generator.processors`, so it was never running.
- `distributor.max_attribute_bytes` was 512, silently truncating attribute values. Set to 2048.
- `querier.frontend_worker.frontend_address` was `0.0.0.0:9095` - that's a bind address, not a connect target. Changed to `${POD_IP}:9095` with `-config.expand-env=true`.
- `service-graphs` processor wait bumped to 60s so Tempo has time to pair spans that arrive through tail sampling (30s window) and batching (6s timeout) from separate Alloy nodes. `metrics_ingestion_time_range_slack` also set to 60s - the default 30s meant spans delayed by tail sampling were outside the metrics generator's acceptance window and silently dropped before service graph edges could be built from them. Added `peer_attributes` to cover modern OTel attributes (`server.address`, `net.peer.name`) that would otherwise render as "unknown" virtual nodes. Added dimensions for HTTP method and path.
- Removed the Prometheus `remote_write` from the metrics generator - Alloy already writes to both Prometheus and Mimir, so Tempo doing the same just doubles the series.
- Added `tempo-headless` service to satisfy the StatefulSet governing service requirement.
- Removed deprecated ports (55680, 55681, 55678), `-mem-ballast-size-mbs` flag (superseded by `GOMEMLIMIT`), `search_encoding: snappy` (no-op with vParquet4), and empty `query_frontend: {}` and `user_configurable_overrides` blocks.

**Grafana**

Grafana generates random UIDs for datasources at startup if no `uid` is set. Any dashboard or datasource that hardcodes a `datasourceUid` (trace-to-logs, exemplars, derived fields) breaks on pod restart. Added explicit UIDs to all five datasources.