### PR TITLE
fix(beyla): update to v3.22.0, fix cluster name bug, adopt 3.15-3.22 config features

### DIFF
--- a/deployment/beyla/cm.yml
+++ b/deployment/beyla/cm.yml
@@ -7,47 +7,67 @@ metadata:
     app.kubernetes.io/name: beyla
 data:
   beyla-config.yml: |
-    open_port: 8000-8999
-    trace_printer: disabled
     log_level: WARN
+    log_format: json
+    shutdown_timeout: 30s
+    enforce_sys_caps: true
+    trace_printer: disabled
     otel_metrics_export:
       endpoint: http://alloy:4317
       protocol: grpc
+      insecure: true
+      ttl: 5m
+      histogram_aggregation: base2_exponential_bucket_histogram
+      instrumentations:
+        - "*"
     otel_traces_export:
       endpoint: http://alloy:4317
       protocol: grpc
+      insecure: true
+      sampler:
+        name: parentbased_always_on
     discovery:
-      services:
+      instrument:
         - k8s_namespace: .
-      exclude_services:
-        - exe_path: ".*alloy.*|.*otelcol.*|.*beyla.*|.*tempo.*|.*loki.*|.*prometheus.*|.*mimir.*|.*grafana.*|.*jaeger.*"
+          containers_only: true
+      exclude_instrument:
+        - exe_path: ".*tempo.*|.*loki.*|.*prometheus.*|.*mimir.*|.*grafana.*"
     attributes:
       kubernetes:
         enable: true
       select:
         beyla_network_flow_bytes:
-          # limit the beyla_network_flow_bytes attributes to only the three attributes
           include:
             - beyla.ip
             - src.name
             - dst.port
         sql_client_duration:
-          # report all the possible attributes but db_statement
           include: ["*"]
           exclude: ["db_statement"]
         http_client_request_duration:
-          # report the default attribute set but exclude the Kubernetes Pod information
-          # exclude: ["k8s.pod.*"]
           include: ["*"]
     filter:
       network:
         k8s_dst_owner_name:
-          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+          not_match: '{kube*,*alloy*}'
         k8s_src_owner_name:
-          not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
-    # prometheus_export:
-    #   path: /metrics
-    #   port: 9090
+          not_match: '{kube*,*alloy*}'
+    routes:
+      unmatched: low-cardinality
+      ignored_patterns:
+        - /health
+        - /healthz
+        - /ready
+        - /readyz
+        - /live
+        - /livez
+        - /metrics
+      ignore_mode: traces
+    metrics:
+      features:
+        - application
+        - application_service_graph
+        - application_span_otel
     # network: Memory and CPU usage increases as Beyla needs to generate more metrics from network traffic
     network:
       enable: false
@@ -57,3 +77,5 @@ data:
       high_request_volume: true
       traffic_control_backend: auto
       context_propagation: "all"
+    health_check:
+      port: 9090

--- a/deployment/beyla/cr.yml
+++ b/deployment/beyla/cr.yml
@@ -10,6 +10,8 @@ rules:
     - "apps"
     resources:
     - "replicasets"
+    - "statefulsets"
+    - "daemonsets"
     verbs:
     - "list"
     - "watch"

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -32,13 +32,13 @@ spec:
             protocol: TCP
           readinessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 9090
             initialDelaySeconds: 10
             periodSeconds: 15
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 9090
             initialDelaySeconds: 30
             periodSeconds: 30
@@ -51,6 +51,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['cluster']
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(NODE_NAME)"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -14,12 +14,9 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
-        filter.by.port.name: "true"
       labels:
         app.kubernetes.io/name: beyla
+        cluster: kubernetes
     spec:
       serviceAccountName: beyla
       hostPID: true           # <-- Important. Required in DaemonSet mode so Beyla can discover all monitored processes
@@ -27,12 +24,24 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
-          image: docker.io/grafana/beyla:3.14.0
+          image: docker.io/grafana/beyla:3.22.0
           imagePullPolicy: IfNotPresent
           ports:
-          - name: metrics
+          - name: health
             containerPort: 9090
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 30
           env:
             - name: BEYLA_CONFIG_PATH
               value: "/etc/beyla/config/beyla-config.yml"
@@ -41,7 +50,7 @@ spec:
             - name: BEYLA_KUBE_CLUSTER_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: spec.nodeName
+                  fieldPath: metadata.labels['cluster']
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:


### PR DESCRIPTION
## What and why

Beyla was pinned at v3.14.0 with a config that hadn't changed across several version bumps. This PR fixes a correctness bug, removes dead config, and brings the setup up to date with features introduced between v3.15 and v3.22.

All changes were validated by running `grafana/beyla:3.22.0` in Docker against the updated config file (same `--memory=896m --cpus=0.1` constraints as the pod). No errors or deprecation warnings on startup.

---

## Bug fixes

**`k8s.cluster.name` was wrong on every node**
`BEYLA_KUBE_CLUSTER_NAME` was set via `spec.nodeName`, which resolves to the individual node hostname. Every Beyla pod on a different node reported a different cluster name, breaking cluster-level grouping in Tempo/Grafana. Fixed by reading `metadata.labels['cluster']` via the downward API, with a matching `cluster: kubernetes` label on the pod template.

**Stale network filter entries**
`filter.network` referenced `*grafana-agent*` and `*promtail*`, both of which were replaced by Alloy. Replaced with `*alloy*`.

**Deprecated discovery keys**
`discovery.services` and `discovery.exclude_services` were renamed to `instrument` and `exclude_instrument` in v3.15. The binary emitted deprecation warnings on every startup.

**Dead annotations removed**
- `prometheus.io/scrape` / `prometheus.io/port: "9090"` referenced a `prometheus_export` block that was commented out
- `filter.by.port.name: "true"` is not a Beyla annotation and had no effect
- Container port `9090` was orphaned once the Prometheus export was disabled

---

## RBAC fix

`statefulsets` and `daemonsets` were missing from the ClusterRole `apps` rule. Without them, Beyla cannot enrich spans from those workload types with the correct `k8s.statefulset.name` / `k8s.daemonset.name` attributes.

---

## New config (v3.15 - v3.22 features)

| Setting | Why |
|---|---|
| `log_format: json` | Loki can parse structured fields directly, no regex extractors needed |
| `shutdown_timeout: 30s` | Longer drain for in-flight eBPF events during rolling updates (default 10s) |
| `enforce_sys_caps: true` | Abort at startup if capabilities are missing - silent degradation is worse than a clear crash |
| `containers_only: true` | `hostPID: true` exposes all node processes; this restricts instrumentation to OCI containers only |
| `routes.unmatched: low-cardinality` | Prevents cardinality explosions from UUIDs and numeric IDs in URL paths |
| `routes.ignored_patterns` | Health/ready/metrics endpoints excluded from traces (response-time metrics still collected) |
| `otel_metrics_export.histogram_aggregation: base2_exponential_bucket_histogram` | Mimir native histograms - better resolution, lower storage cost |
| `otel_metrics_export.ttl: 5m` | Stops reporting stale metrics for terminated pods without a Beyla restart |
| `otel_traces_export.sampler: parentbased_always_on` | Explicit - intent is clear, easy to switch to `traceidratio` later; tail sampling stays in Alloy |
| `metrics.features: application_span_otel` | OTel semconv names (`traces_span_metrics_duration_seconds`) replacing legacy `traces_spanmetrics_latency` |
| `health_check.port: 9090` | Built-in health HTTP server (v3.17+); DaemonSet now has readiness and liveness probes |

`otel_metrics_export.instrumentations` moved from the undocumented top-level `metrics` block to the correct per-exporter location. The top-level field is not in the documented schema and was likely silently ignored.

`exclude_instrument` simplified - `default_exclude_instrument` already covers `*beyla`, `*alloy`, `*otelcol`; only monitoring-stack processes not in that default list need explicit exclusion.

---

## Image

`grafana/beyla:3.14.0` - `3.22.0` (8 releases). Notable fixes picked up:
- Kafka stale traceparent contamination
- gRPC/HTTP2 context propagation via sk_msg HPACK injection
- TCP retransmits and IO metrics
- GraphQL documents no longer exported by default (cardinality)
- LLM/GenAI observability (OpenAI, Anthropic, Gemini)
- Metrics exporter memory leak

---

## Note on span metric names

`application_span_otel` emits `traces_span_metrics_duration_seconds` instead of the legacy `traces_spanmetrics_latency`. No dashboard JSON files exist in this repo so there is nothing to migrate now, but any future dashboards should use the OTel name.