### PR TITLE
fix: bound Loki retention and run Alloy unprivileged

### DIFF
--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -107,9 +107,11 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           securityContext:
-            privileged: true
+            privileged: false
+            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsUser: 0
+            runAsNonRoot: true
+            runAsUser: 473
             seccompProfile:
               type: RuntimeDefault
             capabilities:

--- a/deployment/loki/cm.yml
+++ b/deployment/loki/cm.yml
@@ -48,6 +48,7 @@ data:
       discover_log_levels: true
       reject_old_samples: true
       reject_old_samples_max_age: 168h
+      retention_period: 72h
       volume_enabled: true
 
     schema_config:

--- a/deployment/prometheus/rbac.yml
+++ b/deployment/prometheus/rbac.yml
@@ -58,4 +58,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: monitoring

--- a/deployment/promtail/rbac.yml
+++ b/deployment/promtail/rbac.yml
@@ -34,4 +34,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: promtail
-  namespace: monitoring


### PR DESCRIPTION
## What

- **Loki**: add `limits_config.retention_period: 72h` so the compactor actually trims old data. It had `retention_enabled` set but no period, so it compacted without ever deleting - the 2Gi emptyDir would fill and the kubelet would evict the pod.
- **Alloy**: drop `privileged: true` / `runAsUser: 0` and run as uid 473 non-root. The config only scrapes pprof over HTTP; eBPF profiling is Beyla's job, so Alloy never needed the privilege.
- **Prometheus/Promtail RBAC**: remove the hardcoded `namespace` from the ClusterRoleBinding subjects; the top-level kustomization sets it.

## Testing

Deployed both changes in an isolated namespace on the local kind cluster:

- Loki came up healthy (0 restarts); `/config` shows retention active and the compactor retention metrics are present.
- Alloy with the full real config came up Ready as uid 473 with a read-only root filesystem and 0 errors. Confirmed via `kubectl diff` that the only change vs the running daemonset is the securityContext.

`kubectl kustomize deployment` builds clean and every RBAC subject still resolves to the `monitoring` namespace.
