### PR TITLE
fix: stop Grafana crash-looping on bundled plugin preinstall

### DIFF
--- a/deployment/grafana/cm.yml
+++ b/deployment/grafana/cm.yml
@@ -158,4 +158,5 @@ data:
     enable_alpha=true
     plugin_admin_enabled=true
     preinstall_async=false
+    preinstall_auto_update=false
     preinstall=aws-datasource-provisioner-app,grafana-llm-app,grafana-synthetic-monitoring-app,redis-explorer-app,grafana-oncall-app,grafana-github-datasource,grafana-resourcesexporter-app,grafana-advisor-app,grafana-x-ray-datasource,grafana-opensearch-datasource,computest-cloudwatchalarm-datasource,grafana-googlesheets-datasource,victoriametrics-logs-datasource,victoriametrics-metrics-datasource,googlecloud-trace-datasource,grafana-bigquery-datasource,googlecloud-logging-datasource,grafana-sentry-datasource,grafana-enterprise-logs-app,grafana-metrics-enterprise-app,grafana-enterprise-traces-app,grafana-lokiexplore-app,grafana-metricsdrilldown-app,grafana-pyroscope-app,grafana-exploretraces-app,grafana-assistant-app,grafana-graphviz-panel,grafana-cloudflare-datasource,grafana-databricks-datasource,grafana-dynamodb-datasource,grafana-gitlab-datasource,grafana-lokioperational-app

--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:13.0.1
+        image: docker.io/grafana/grafana:13.0.2
         imagePullPolicy: IfNotPresent
         env:
         - name: GOMAXPROCS


### PR DESCRIPTION
## What

- Set `preinstall_auto_update=false` in the grafana.ini `[plugins]` section.
- Drop the `GF_PLUGINS_PREINSTALL_DISABLED=true` workaround (it disabled the whole preinstall list) and the redundant `GF_PATHS_DATA` env (the image already defaults it to `/var/lib/grafana`).
- Bump Grafana to `13.0.2`.

## Why

Grafana 13 ships `elasticsearch` as a bundled plugin under `/usr/share/grafana/data/plugins-bundled/`, which sits on the read-only root filesystem. With `preinstall_auto_update` on, the startup preinstaller tries to update that bundled plugin in place, hits `unlinkat ... read-only file system`, and - being synchronous - takes the whole process down (CrashLoopBackOff). `preinstall_auto_update=false` leaves the bundled plugin at its image version while still preinstalling the configured plugin list.

## Testing

On a local kind cluster with `readOnlyRootFilesystem: true` and the real grafana.ini:

- Reproduced the original crash, then confirmed the fix: 0 restarts, ready, 0 read-only/failed-install errors, plugin list installs to the writable volume.
- Verified `GF_PATHS_DATA` is redundant - the image logs `GF_PATHS_DATA=/var/lib/grafana` as a built-in override even when unset, and plugins still land in `/var/lib/grafana/plugins` without it.
- Re-ran on `13.0.2` (`Version 13.0.2`, commit 3fcdbc5a): pulls, starts clean, 0 errors. Its bundled elasticsearch is 12.6.2; `auto_update=false` correctly skips the catalog update.

`kubectl kustomize deployment` builds clean.
