### PR TITLE
chore(deps): bump Grafana image from 13.0.2 to 13.1.1

### DIFF
--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:13.0.2
+        image: docker.io/grafana/grafana:13.1.1
         imagePullPolicy: IfNotPresent
         env:
         - name: GOMAXPROCS


### PR DESCRIPTION
Bumps the Grafana image from 13.0.2 to 13.1.1.

Routine version bump to pick up the latest 13.1.x fixes and improvements. No manifest changes beyond the image tag; deployment spec, security context, and probes are unchanged.