### PR TITLE
chore(deps): bump Alloy image from v1.16.2 to v1.18.0

### DIFF
--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -27,7 +27,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.16.2
+          image: docker.io/grafana/alloy:v1.18.0
           imagePullPolicy: IfNotPresent
           args:
             - run


### PR DESCRIPTION
Bumps the Alloy DaemonSet image from v1.16.2 to v1.18.0.

## Breaking changes

v1.18.0 ships three. Two do not apply to us:

- `otelcol.exporter.splunkhec` - the `batcher` block was removed upstream in otel-contrib v0.151. We do not use this component.
- `otelcol.receiver.kafka` / `otelcol.exporter.kafka` - `resolve_canonical_bootstrap_servers_only` is now a no-op after the sarama to franz-go migration. We do not use these either.

The third does apply. The HTTP servers on `otelcol.receiver.otlp` (and the other OTel receivers) now default to `idle_timeout = "1m"`, `read_header_timeout = "1m"` and `write_timeout = "30s"`, matching upstream. They previously defaulted to `0s`. Our `otelcol.receiver.otlp "otel"` has an `http` block, so it inherits these.

v1.17.0 had no breaking changes.

## Why the new timeouts are left alone

They can be pinned back to `0s` to restore the old behaviour, but that is worse. OTLP/HTTP is short request/response, so the timeouts are not reachable in normal operation, and idle keep-alives just reconnect. The only difference shows up under backpressure: with Tempo, Loki or Mimir down, the consumer chain blocks and a push now aborts at 30s rather than hanging indefinitely. Failing is better than hanging, and it matches what upstream ships by default.

## Verification

Extracted `config.alloy` from the ConfigMap and ran it under the v1.18.0 image with the exact flags this DaemonSet passes - `--stability.level=public-preview`, `--feature.community-components.enabled`, `--cluster.enabled=true`. With the in-cluster environment stubbed out, the full graph built and ran steadily at `level=debug`: all 41 components, no schema errors, no removed arguments, no deprecation warnings.

`service.yml` needs nothing - ports 12345, 4317 and 4318 are unaffected. In `daemonset.yml` every CLI flag, the `/-/ready` probe and the read-only-root, non-root securityContext are all still valid.

## Worth watching

`otelcol.exporter.loki` and `otelcol.exporter.prometheus` both still exist in v1.18.0 and emitted no deprecation warning, but they are the components most likely to move in a future release. Worth re-checking on the next bump.

Closes #258
