### PR TITLE
chore(deps): bump Loki image from 3.7.2 to 3.7.4

### DIFF
--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -30,7 +30,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.7.2
+          image: docker.io/grafana/loki:3.7.4
           imagePullPolicy: IfNotPresent
           args:
             - -target=all


### PR DESCRIPTION
Closes #260

Bumps the Loki StatefulSet image from 3.7.2 to 3.7.4.

## What is in the two releases

3.7.3 is CI and security dependency bumps only - the Go toolchain, `golang.org/x/crypto`, `x/net`, `x/sys`, `containerd` and `otel`. Nothing functional changes in the server.

3.7.4 needs a word of warning, because its changelog entry looks far worse than it is. release-please generated it malformed - the heading compares `v3.7.3...v3.7.3` and the body replays the entire 3.7.0 feature list, so at a glance it reads like a major release landed in a patch. The only item under BREAKING CHANGES is `operator: switch default for OpenShift stream labels`. That is the Loki Operator on OpenShift. We do not use it - this repo runs a plain StatefulSet - so it does not reach us.

## Verification

Extracted `loki.yaml` from the ConfigMap and ran `-verify-config` under both the 3.7.2 and 3.7.4 images. Both pass.

More usefully, I diffed the fully resolved config each version prints via `-print-config-stderr`. All 3580 lines are identical once the version banner and the per-container `instance_id` are excluded. No default has shifted underneath us, which is the failure mode that would otherwise degrade ingestion or retention without the pod ever failing to start.

Since then this has also been deployed to a kind cluster as part of the full stack. `loki-0` reaches `/ready` with a 200 and runs with zero restarts, and Loki is accepting writes from Alloy - a `query_range` returns live streams across 16 labels. So the push path is confirmed working end to end on 3.7.4, not just the config.

`deployment/loki/cm.yml` and `service.yml` need nothing.

## Correction: Promtail is not deployed

An earlier version of this description implied the Promtail DaemonSet is running and needs retiring. **That was wrong, and I am correcting it rather than quietly editing it away.**

`deployment/kustomization.yml` has `# - promtail/` commented out, so Promtail is not part of the applied stack at all. Confirmed on the kind deploy: the namespace comes up with exactly two DaemonSets, `alloy` and `beyla`, and no Promtail pod.

What remains true is narrower and less urgent. `deployment/promtail/daemonset.yml` still exists in the tree pinned at 3.7.2, and `grafana/promtail:3.7.3` and `:3.7.4` do not exist, because the 3.7.x line carries `Remove Promtail support` - Promtail is EOL with 3.7.2 as its final image. So the manifest is dead weight referencing an end-of-life image rather than a live component drifting out of support. Deleting it is tidy-up, not a behavioural change, and still belongs in its own PR rather than here.
