### PR TITLE
chore(deps): bump Mimir image from 3.1.0 to 3.1.4

### DIFF
--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -28,7 +28,7 @@ spec:
         - '-config.file=/conf/mimir.yaml'
         - '-log.format=json'
         - '-log.level=warn'
-        image: docker.io/grafana/mimir:3.1.0
+        image: docker.io/grafana/mimir:3.1.4
         imagePullPolicy: IfNotPresent
         name: mimir
         env:


### PR DESCRIPTION
Bumps the Mimir StatefulSet image from 3.1.0 to 3.1.4.

## What is in the range

No breaking changes. Every release between the two is bugfix or CVE work:

- **3.1.1** - image base moves from Debian 12 to Debian 13; Go 1.26.4 for CVE-2026-42507; `golang.org/x/crypto`, `x/net` and `x/sys` bumped for a batch of CVEs.
- **3.1.2** - caps the Kafka protocol version the client negotiates. Ingest storage only, which we do not use.
- **3.1.3** - fixes a Windows and FreeBSD build failure; Go 1.26.5 for two more CVEs.
- **3.1.4** - sets the executable bit on the DEB and RPM binaries. Package installs only, irrelevant to containers.

The one entry marked `[CHANGE]` is the Debian base bump. That is the container base rather than config semantics, so nothing in `mimir.yaml` is touched by it.

## Verification

Two passes, because "the changelog says it is fine" is not the same as knowing.

Dumped the fully resolved config from both images with `-print.config`. All 2628 lines are identical once the per-container `instance_id` is excluded - no default has shifted underneath us, which is the failure mode that would quietly change retention or compaction behaviour without the pod ever failing to start.

Then booted 3.1.4 against the real `mimir.yaml` with the filesystem paths mounted. It reached `/ready` with a 200 in roughly 18 seconds. The only warning it logs is the existing `blocks-storage.backend=filesystem is for development and testing only` advisory, which is deliberate for this stack and logs identically on 3.1.0.

`deployment/mimir/cm.yml`, `service.yml` and the rest of `statefulset.yml` need nothing.

## Why not leave it

3.1.1 and 3.1.3 both carry Go CVE fixes, so 3.1.0 is not a neutral place to sit. This is a security rollup rather than housekeeping.

## Note on the tag

Mimir does not use a `v` prefix on its image tags - `grafana/mimir:v3.1.4` does not exist. The tag here is `3.1.4`, consistent with how 3.1.0 was already pinned, and unlike Alloy which does use `v`.

Closes: #262
