### PR TITLE
chore(deps): bump Pyroscope image from 2.0.3 to 2.2.0

### DIFF
--- a/deployment/pyroscope/deployment.yml
+++ b/deployment/pyroscope/deployment.yml
@@ -27,7 +27,7 @@ spec:
         runAsUser: 10001
       containers:
       - name: pyroscope
-        image: docker.io/grafana/pyroscope:2.0.3
+        image: docker.io/grafana/pyroscope:2.2.0
         imagePullPolicy: IfNotPresent
         args:
           - "-config.file=/etc/pyroscope/config.yaml"


### PR DESCRIPTION
Closes #263

Bumps the Pyroscope Deployment image from 2.0.3 to 2.2.0.

## What is in the range

Nothing in the range is marked breaking, and no config key was removed or renamed. Diffing the generated flag reference between the two tags gives **0 flags removed, 0 renamed, 15 added**, and every addition is opt-in. 2.0.4, 2.0.5, 2.0.6 and 2.1.1 are dependency and CVE patches only.

## The one default that moves

`metastore.index.cleanup_interval` changes in 2.2.0 from `0`, meaning disabled, to `15m`. Metastore index retention cleanup now runs where it previously never did. We do not set the key, so we inherit the change.

Left inherited rather than pinned back. We run on an emptyDir, and an index that is never pruned grows until the volume fills - that is the failure mode this default was changed to prevent. Setting it back to `0` would preserve today's exact behaviour at the cost of reintroducing unbounded growth, which is not a trade worth making here.

## Other behaviour changes, none of which reach us

- **2.2.0** - `/ingest?sampleRate=` values of zero or less are now rejected and fall back to the documented default of 100, rather than wrapping to a huge number. Beyla exports profiles over OTLP and sets no sample rate.
- **2.2.0** - ingestion limit rejections now return 429 on the OTLP and `/ingest` paths.
- **2.2.0** - the auth interceptor now fails closed when tenant header extraction fails. Multitenancy only; we run with it off.
- **2.1.0** - new `recording-rules.max-rules-per-tenant` limit, default 25. We define no recording rules.
- **2.1.0** - the Helm chart now defaults to the v2 storage architecture. Helm only; it does not change the binary's `-architecture.storage` default, which is still `v1-v2-dual` in both tags.

Storage defaults relevant to a single-binary deployment are unchanged across the range: `-architecture.storage`, `-storage.backend`, `-storage.filesystem.dir` and `-pyroscopedb.data-path` all hold their 2.0.3 values.

## Verification

Booted both 2.0.3 and 2.2.0 against the real `config.yaml` and `overrides.yaml`, with the ring hostname made resolvable so memberlist could form. Both accept the config identically and stay up with no parse errors.

Worth being precise about the limit here: neither version reached a `200` on `/ready` in a single-container harness, because the ring never fully stabilises with one member - both sat on `Segment Writer not ready: waiting for 30s after being ready`. That is identical on the current version, so it is a property of the test setup rather than anything 2.2.0 introduced. What this confirms is config acceptance and process stability, not full readiness.

`deployment/pyroscope/cm.yml` and `service.yml` need nothing.
