### PR TITLE
chore(deps): bump Prometheus image from v3.11.3 to v3.13.1

### DIFF
--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v3.11.3
+          image: docker.io/prom/prometheus:v3.13.1
           imagePullPolicy: IfNotPresent
           env:
             - name: GOMAXPROCS


### PR DESCRIPTION
Closes #265

Bumps the Prometheus Deployment image from v3.11.3 to v3.13.1.

## The CLI surface, which is the part that would actually take us down

No flag was removed or renamed. Diffing the command-line docs between the two tags shows additions only: `--config.auto-reload`, `--web.search.max-limit`, and two agent-mode storage flags.

The `--enable-feature` list was checked directly against the `setFeatureListOptions` switch in `cmd/prometheus/main.go` at both tags rather than trusting the docs. **No feature name was removed.** `auto-reload-config` was promoted to stable in v3.12.0 and now logs a deprecation pointing at `--config.auto-reload`, but we do not pass it. Unknown names have always been warn-only and have never been fatal, so even a retired name would not have stopped the pod.

## What can actually be felt

Three v3.12.0 changes touch receivers we expose:

- **Remote write now rejects snappy payloads whose declared decoded length exceeds 32 MB.** We run `--web.enable-remote-write-receiver`, so this is the change most likely to bite. Our only writers are in-cluster Alloy instances sending ordinary batches, so it should not, but it is the one to watch.
- **Gzip-encoded OTLP writes now have a decompressed body limit.** We run `--web.enable-otlp-receiver`.
- **`remote_write` `queue_config` is now validated at config load** instead of panicking later. Does not reach us - our `remote_write` block is commented out.

From v3.13.0, HTTP clients no longer forward credentials on redirect to a different host, covering scraping, remote read and write, alerting and service discovery. Every scrape job here authenticates to the in-cluster API server with `bearer_token_file` and does not redirect cross-host, so this is a non-event for us - but it is the item most likely to matter if a job is ever pointed outside the cluster.

The remaining v3.13.0 changes do not apply: the PromQL `min()`/`max()` to `min_of()`/`max_of()` rename is behind `promql-duration-expr`, which we do not enable; rule-group pagination tokens moving to SHA-256 affects API consumers; and `npm_licenses.tar.bz2` being dropped from the image is packaging.

`prometheus.yml` gained fields only - new `__meta_kubernetes_node_condition_*` meta labels, `outscale_sd_configs`, and some storage and relabel additions. Our four `kubernetes_sd_configs` jobs on the `endpoints` and `node` roles are untouched.

## Verification

`promtool check config` under both images gives byte-identical output: config valid, 4 rule files found, 11 alerting rules parsed.

Then booted both versions with the exact argument list this Deployment passes, including the full `--enable-feature` string, and both start and stay up. The only errors logged are in-cluster service discovery failures, which are environmental and appear identically on both.

## Noted, not changed

`native-histograms` in our `--enable-feature` list is a no-op and already was one on v3.11.3 - native histograms are configured through the `scrape_native_histograms` scrape setting instead. It is dead weight rather than a new break, so removing it belongs in its own change rather than being folded into a version bump.
