### PR TITLE
chore(deps): bump Beyla image from 3.22.0 to 3.30.0 and mount tracefs

### DIFF
--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -24,7 +24,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
-          image: docker.io/grafana/beyla:3.22.0
+          image: docker.io/grafana/beyla:3.30.0
           imagePullPolicy: IfNotPresent
           ports:
           - name: health
@@ -91,8 +91,10 @@ spec:
             - mountPath: /etc/beyla/config
               name: beyla-config
             - name: cgroup
-              mountPath: /sys/fs/cgroup # <-- Important. Allows Beyla to monitor all newly sockets to track outgoing requests. 
+              mountPath: /sys/fs/cgroup # <-- Important. Allows Beyla to monitor all newly sockets to track outgoing requests.
               readOnly: true
+            - name: tracefs
+              mountPath: /sys/kernel/tracing # <-- Important. Required from 3.28.0 for context propagation, which uses normal tracepoints.
       volumes:
         - name: beyla-config
           configMap:
@@ -100,3 +102,6 @@ spec:
         - name: cgroup
           hostPath:
             path: /sys/fs/cgroup
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing


### PR DESCRIPTION
Closes #267

Bumps Beyla from 3.22.0 to 3.30.0 and adds the hostPath mount that becomes necessary along the way. Unlike the other bumps in this batch, this one is not a one-line change.

## How the changes were found

None of the eight releases declares a breaking-changes section - Grafana publishes Beyla notes as flat commit and PR title lists. The real changes are in the vendored OBI submodule and had to be found by diffing `docs/config-schema.json` and the docs between `v3.22.0` and `v3.30.0`. Reading the release notes alone would have missed every item below.

## The manifest change

From **3.28.0**, context propagation uses normal rather than raw tracepoints, as part of the 3.27.0 FIONREAD kernel-bug mitigation. Normal tracepoints require tracefs to be mounted. Our config sets `ebpf.context_propagation: "all"`, so this applies to us.

Added `/sys/kernel/tracing` as a `tracefs` hostPath next to the existing cgroup mount. This matches the upstream chart, which gates both mounts on the same `contextPropagation.enabled` condition - we already had the cgroup half and were missing this one. Helm users get it for free; a hand-rolled DaemonSet like ours does not.

## What was checked and did not need changing

**`context_propagation: "all"` is still valid.** The schema did change here - the undocumented `http` alias was dropped from the comma-separated form - but `"all"` lives in a separate enum branch that is byte-identical in both tags. Verified against the schema rather than assumed, because this was the item most likely to break us.

**Capabilities are fine.** 3.28.0 starts requiring `CAP_PERFMON` for the socket_filter network path. We already grant `PERFMON`, we run `privileged: true` regardless, and `network.enable` is `false`. The docs also flipped `SYS_ADMIN` from commented-out to required, but that is guidance rather than an enforced check, and privileged covers it either way. Minimum kernel is unchanged at 5.8.

**Nothing removed or renamed touches our config.** The injector selector renames (`namespaces` to `k8s_namespace` and friends) need an `injector:` block, which we do not have. `jvm_runtime_metrics` was removed in 3.29.0 but only existed from 3.24.0, so we never carried it, and our `metrics.features` does not list `application_jvm`.

## Behaviour changes we inherit

None of these need config work, but they change what you will see:

- **3.23.0** - `discovery.disabled_route_harvesters` defaults from `[]` to `["java"]`, so Java route harvesting stops. It was disabled upstream because it could block the JVM. Set it back to `[]` explicitly if we want it.
- **3.23.0** - environment-variable-based language detection removed. Expect fewer false-positive .NET services; detection now relies on the stronger `libcoreclr.so` signal.
- **3.25.0** - `url.query` is now emitted on HTTP spans by default, with sensitive parameters auto-redacted.
- **3.29.0** - OTLP-side meta-metrics renamed: `target_info` to `target.info`, `traces_target_info` to `traces.target.info`, `traces_host_info` to `traces.host.info`. Prometheus-side names are unchanged. **This will break any OTLP dashboard querying the old underscore names.**
- **3.29.0** - `exclude_otel_instrumented_services` now actually works for gRPC exporters, having previously compared the wrong port. More services will be auto-excluded than before, so if something disappears from Beyla metrics after this rolls out, that is why.
- **3.30.0** - dependency bumps and an OBI pointer only, no functional change.

## Verification

Validated the extracted `beyla-config.yml` against `docs/config-schema.json` at both 3.22.0 and 3.30.0. Both produce the same two findings, and both are the same pre-existing quirk: `attributes.kubernetes.enable` is a YAML boolean where the schema wants the string `"true"`. Identical on the version we already run, so it is not a regression and is left alone.

`kubectl kustomize deployment/beyla` builds cleanly with the new volume.

Worth stating plainly: eBPF attach behaviour cannot be verified off-cluster, so the tracefs mount is justified from the upstream chart and the OBI change rather than observed working. This one wants a look at Beyla's logs on the first node after rollout.
