### PR TITLE
feat(tracing): remove Alloy tail sampling so Tempo can pair spans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ALLOY_IMAGE    ?= docker.io/grafana/alloy:v1.16.2
+ALLOY_IMAGE    ?= docker.io/grafana/alloy:v1.18.0
 KIND_CLUSTER   ?= loki-stack
 KUBE_NAMESPACE ?= monitoring
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ GRAFANA DATASOURCES:
 ┌─────────────────┬─────────────────┬──────────────────────────────────────┐
 │ DATASOURCE      │ QUERY LANGUAGE  │ ENDPOINT                             │
 ├─────────────────┼─────────────────┼──────────────────────────────────────┤
-│ Prometheus      │ PromQL          │ http://prometheus-server:9090        │
-│ Mimir           │ PromQL          │ http://mimir:8080/prometheus         │
+│ Prometheus      │ PromQL          │ http://prometheus-server             │
+│ Mimir           │ PromQL          │ http://mimir/prometheus              │
 │ Loki            │ LogQL           │ http://loki:3100                     │
-│ Tempo           │ TraceQL         │ http://tempo:3200                    │
-│ Pyroscope       │ Pprof           │ http://pyroscope:4100                │
+│ Tempo           │ TraceQL         │ http://tempo:3100                    │
+│ Pyroscope       │ Pprof           │ http://pyroscope:4040                │
 └─────────────────┴─────────────────┴──────────────────────────────────────┘
 ```
 

--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -215,32 +215,14 @@ data:
       }
       output {
         traces = [
-          otelcol.processor.tail_sampling.rate_limiter.input,
-        ]
-      }
-    }
-
-    otelcol.processor.tail_sampling "rate_limiter" {
-      policy {
-        name = "sample-errors"
-        type = "status_code"
-        status_code {
-          status_codes = ["ERROR"]
-        }
-      }
-      policy {
-        name = "rate-limit-ok"
-        type = "rate_limiting"
-        rate_limiting {
-          spans_per_second = 400
-        }
-      }
-      output {
-        traces = [
           otelcol.processor.batch.otel.input,
         ]
       }
     }
+
+    // No tail sampling: it is stateful and Alloy is a DaemonSet, so without an
+    // otelcol.exporter.loadbalancing tier routing on traceID it decides on partial traces,
+    // splitting the client/server pairs Tempo's service-graph processor needs. See #269.
 
     otelcol.receiver.otlp "otel" {
       grpc {

--- a/deployment/beyla/cm.yml
+++ b/deployment/beyla/cm.yml
@@ -75,7 +75,9 @@ data:
     metrics:
       features:
         - application
-        - application_service_graph
+        # application_service_graph omitted: Beyla emits the same traces_service_graph_*
+        # names as Tempo's generator but with extra labels, and Grafana sums by
+        # (client, server), merging both. Tempo owns the service graph. See #269.
         - application_span_otel
     # network: Memory and CPU usage increases as Beyla needs to generate more metrics from network traffic
     network:

--- a/deployment/grafana/cm.yml
+++ b/deployment/grafana/cm.yml
@@ -97,8 +97,6 @@ data:
       url: http://tempo:3100
       jsonData:
         httpMethod: GET
-        tracesToLogs:
-          datasourceUid: Loki
         tracesToLogsV2:
           datasourceUid: Loki
           spanStartTimeShift: '-15m'
@@ -118,8 +116,6 @@ data:
           enabled: true
         search:
           hide: false
-        lokiSearch:
-          datasourceUid: Loki
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -83,6 +83,8 @@ data:
               endpoint: 0.0.0.0:4317
             http:
               endpoint: 0.0.0.0:4318
+        zipkin:
+          endpoint: 0.0.0.0:9411
     server:
       log_level: warn
       log_format: json

--- a/docs/alloy.md
+++ b/docs/alloy.md
@@ -6,13 +6,13 @@ This stack uses Alloy in place of Promtail. The Promtail directory is still in t
 
 ## What it runs
 
-- DaemonSet, image `docker.io/grafana/alloy:v1.16.2`.
-- Args: `run /etc/alloy/config.alloy --storage.path=/tmp/alloy --server.http.listen-addr=$(POD_IP):12345 --stability.level=public-preview --feature.community-components.enabled --cluster.enabled=true --cluster.name=$(CLUSTER_NAME) --cluster.wait-for-size=1`.
+- DaemonSet, image `docker.io/grafana/alloy:v1.18.0`.
+- Args: `run /etc/alloy/config.alloy --storage.path=/tmp/alloy --server.http.listen-addr=$(POD_IP):12345 --server.http.ui-path-prefix=/ --stability.level=public-preview --feature.community-components.enabled --cluster.enabled=true --cluster.name=$(CLUSTER_NAME) --cluster.wait-for-size=1`.
 - `CLUSTER_NAME` is read from the pod label `cluster` via the downward API, so it's set in the DaemonSet pod template rather than hardcoded in the args.
 - Ports: 12345 (HTTP UI and self metrics), 4317 (OTLP gRPC), 4318 (OTLP HTTP).
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 896Mi.
 - Storage: 1 Gi emptyDir at `/tmp/alloy` for remote_write WAL buffers.
-- Security: privileged container so it can read kubelet metrics and pod stdout, read-only root filesystem, runs as UID 0.
+- Security: unprivileged — `privileged: false`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `runAsUser: 473`, all capabilities dropped, `seccompProfile: RuntimeDefault`.
 - RBAC: ClusterRole grants list/watch on pods, services, nodes, endpoints, endpointslices, ingresses, events, configmaps and replicasets, plus the Prometheus operator CRDs (`podmonitors`, `servicemonitors`, `probes`, `scrapeconfigs`, `prometheusrules`) and `monitoring.grafana.com/podlogs`.
 
 ## Configuration
@@ -53,31 +53,21 @@ prometheus.remote_write "mimir" {
 
 A single `prometheus.scrape "default"` block walks kubelet pod targets, nodes and services and forwards to both writers. Targets with `prometheus.io/scrape: "false"` get dropped during relabel.
 
-Traces come in on OTLP, get K8s metadata attached, pass through tail sampling, and split: one copy goes to Tempo, the other feeds the service-graph connector:
+Traces come in on OTLP, get K8s metadata attached, and are forwarded to Tempo unsampled:
 
 ```river
 otelcol.receiver.otlp "otel" {
   grpc { endpoint = sys.env("POD_IP") + ":4317" }
   http { endpoint = sys.env("POD_IP") + ":4318" }
-}
 
-otelcol.processor.tail_sampling "rate_limiter" {
-  policy {
-    name = "sample-errors"
-    type = "status_code"
-    status_code { status_codes = ["ERROR"] }
-  }
-  policy {
-    name = "rate-limit-ok"
-    type = "rate_limiting"
-    rate_limiting { spans_per_second = 400 }
-  }
-}
-
-otelcol.connector.servicegraph "tempo" {
-  dimensions = ["http.method", "http.request.method", "http.target", "url.path"]
   output {
-    metrics = [otelcol.exporter.prometheus.otel.input]
+    traces = [otelcol.processor.k8sattributes.default.input]
+  }
+}
+
+otelcol.processor.k8sattributes "default" {
+  output {
+    traces = [otelcol.processor.batch.otel.input]
   }
 }
 
@@ -89,9 +79,17 @@ otelcol.exporter.otlp "tempo" {
 }
 ```
 
-Errored spans are always sampled, everything else is capped at 400 spans/s. The service-graph connector emits `traces_service_graph_*` metrics for span pairs it sees on the local node.
-
 Batch settings: 6 second timeout, 200 spans per batch, 300 max.
+
+### Why there is no tail sampling and no service-graph connector here
+
+Alloy generates **no** trace-derived metrics. `traces_service_graph_*` and `traces_spanmetrics_*` come from [Tempo's](./tempo.md) `metrics_generator`, which is the only producer in this stack.
+
+Alloy also does no sampling, deliberately. `otelcol.processor.tail_sampling` and `otelcol.connector.servicegraph` are both **stateful**: they need every span of a trace on one instance. Alloy runs as a DaemonSet behind a ClusterIP Service, so spans of a single trace land on different pods. Without an `otelcol.exporter.loadbalancing` tier routing on `traceID`, both components would work from partial traces — splitting the client/server span pairs that Tempo's service-graph processor has to match, and so producing an empty or truncated service graph.
+
+Tail sampling also delays every span by `decision_wait` (30s by default) before releasing it. Tempo drops any span whose end time falls outside `metrics_ingestion_time_range_slack` (60s in [`deployment/tempo/cm.yml`](../deployment/tempo/cm.yml)), so that delay consumes most of the budget and silently discards spans from metric generation.
+
+To sample at scale, add a second Alloy tier: DaemonSet agents exporting via `otelcol.exporter.loadbalancing` with `routing_key = "traceID"` into a separate Alloy Deployment behind a headless Service that runs `tail_sampling`.
 
 ## Profiling
 
@@ -164,7 +162,7 @@ pyroscope.write "pyroscope" {
 
 ## Inputs
 
-- Applications send OTLP logs, metrics and traces to the local Alloy on the node, port 4317 (gRPC) or 4318 (HTTP).
+- Applications send OTLP logs, metrics and traces to the `alloy` Service on port 4317 (gRPC) or 4318 (HTTP). Note this is a ClusterIP Service with `internalTrafficPolicy: Cluster`, so traffic is balanced across every Alloy pod — it is not pinned to the local node.
 - The kubelet at `https://$NODE_IP:10250` is the source for pod targets and pod logs.
 - Pods with `profiles.grafana.com/port: "<n>"` or per-type `profiles.grafana.com/<type>.scrape: "true"` annotations are scraped for pprof profiles.
 


### PR DESCRIPTION
Fixes #269

Tempo's service-graph processor can only emit an edge if it sees both the client span and the callee's server span from the same trace. The shipped Alloy config made that unreliable, and the docs described a pipeline the config has never had.

## Alloy: tail sampling removed

`otelcol.processor.tail_sampling` is stateful and needs every span of a trace on one instance. Alloy runs as a DaemonSet behind a ClusterIP Service, so spans of one trace land on different pods, and there is no `otelcol.exporter.loadbalancing` tier to route on `traceID`. Each pod was deciding on a partial trace and splitting client/server pairs.

It also delayed every span by `decision_wait` (30s default) plus the 6s batch, against Tempo's 60s `metrics_ingestion_time_range_slack` - a symmetric window on span end time applied before any processor runs. That was discarding ~7% of spans as `outside_metrics_ingestion_slack` on a live cluster, and it drops the older half of a would-be pair, so it corrupts pairing rather than just thinning it.

Nothing replaces it. Tempo is a single-replica `target: all` deployment, so with no stateful processor in Alloy every span converges on one metrics-generator and pairs correctly. A comment in the config records why it is absent and what the two-tier shape looks like if sampling is wanted later.

## Beyla: service graph ownership

Dropped `application_service_graph`. Beyla emits the same metric names as Tempo's generator but adds `source` and service-namespace labels, and Grafana sums by `(client, server)` - so both producers merged into one graph built from two shapes. Tempo owns it now.

## Tempo: Zipkin receiver added

Port 9411 was already exposed in the StatefulSet and Service and documented in `docs/tempo.md`, but `distributor.receivers` only defined `jaeger` and `otlp`. Nothing was listening on it.

## Docs and hygiene

`docs/alloy.md` documented an `otelcol.connector.servicegraph "tempo"` block that has never existed in the config - `git log -S` finds no commit that added it. Also corrected the image version, the args, and the security context: the docs claimed a privileged container running as UID 0, while the DaemonSet sets `privileged: false` and `runAsUser: 473`.

README's datasource table had three wrong ports (Mimir 80 not 8080, Tempo 3100 not 3200, Pyroscope 4040 not 4100). The Tempo datasource carried `tracesToLogs` (the v1 shape, superseded by `tracesToLogsV2` which is already configured) and a top-level `lokiSearch` object that nothing on Grafana 13 reads - `lokiSearch` is gone from `TempoQueryType`, and its only surviving reference in Grafana is a boolean sub-field of the deprecated `tracesToLogs` interface. Trace-to-logs still works through `tracesToLogsV2` and the Loki `derivedFields` TraceID link. `Makefile` pinned alloy v1.16.2 for `alloy fmt` while the DaemonSet runs v1.18.0.

## Verification

- `alloy validate` (full component graph, with the same stability and community-component flags the DaemonSet uses) exits 0 against the edited config
- Started Tempo against the edited config and confirmed the new receiver: `POST /api/v2/spans` returns 202. Note `tempo -config.verify=true` is not a useful check here - it also passes a deliberately bogus receiver key, so it was not relied on
- `kubectl kustomize deployment/` renders 40 documents; all five datasource provisioning YAMLs parse, as do the embedded `tempo.yaml` and `beyla-config.yml`

## Caveat

This unblocks pairing, it does not create spans. Edges only appear between services that are both instrumented and propagate trace context. A client span whose callee is silent still shows up as a virtual node or a database peer rather than a service-to-service edge.