### PR TITLE
chore(alloy): drop Service discovery so pods are scraped once

### DIFF
--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -25,10 +25,6 @@ data:
       role = "node"
     }
 
-    discovery.kubernetes "services" {
-      role = "service"
-    }
-
     discovery.relabel "pod_logs" {
       targets = discovery.kubelet.pods.targets
       rule {
@@ -41,8 +37,8 @@ data:
       }
     }
 
-    discovery.relabel "all_targets_with_address" {
-      targets = array.concat(discovery.kubelet.pods.targets, discovery.kubernetes.nodes.targets, discovery.kubernetes.services.targets)
+    discovery.relabel "pod_targets" {
+      targets = discovery.kubelet.pods.targets
       rule {
         action = "drop"
         regex = "Succeeded|Failed"
@@ -55,13 +51,6 @@ data:
         separator = "@"
         source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
         target_label = "service_name"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_service_name"]
-        regex         = ".+"
-        target_label  = "source"
-        replacement   = "services"
-        action        = "replace"
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_container_name"]
@@ -81,6 +70,40 @@ data:
         action       = "keep"
       }
       rule {
+        action = "labelmap"
+        regex  = "__meta_kubernetes_pod_label_(.+)"
+      }
+      rule {
+        action = "replace"
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label = "namespace"
+      }
+      rule {
+        action = "replace"
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "pod_template_hash|controller_revision_hash|checksum_.*|pod_uid|instance|job"
+      }
+    }
+
+    discovery.relabel "node_targets" {
+      targets = discovery.kubernetes.nodes.targets
+      rule {
+        action        = "replace"
+        source_labels = ["__meta_kubernetes_node_name"]
+        regex         = ".+"
+        target_label  = "source"
+        replacement   = "nodes"
+      }
+      rule {
+        action        = "replace"
+        source_labels = ["__meta_kubernetes_node_name"]
+        target_label  = "node"
+      }
+      rule {
         action        = "replace"
         source_labels = ["__meta_kubernetes_node_label_kubernetes_io_hostname"]
         regex         = "(.+)"
@@ -97,28 +120,6 @@ data:
         source_labels = ["__meta_kubernetes_node_label_topology_kubernetes_io_region"]
         regex         = "(.+)"
         target_label  = "region"
-      }
-      rule {
-        action = "labelmap"
-        regex  = "__meta_kubernetes_pod_label_(.+)"
-      }
-      rule {
-        action = "labelmap"
-        regex  = "__meta_kubernetes_service_label_(.+)"
-      }
-      rule {
-        action = "replace"
-        source_labels = ["__meta_kubernetes_namespace"]
-        target_label = "namespace"
-      }
-      rule {
-        action = "replace"
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        target_label = "node"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "pod_template_hash|controller_revision_hash|checksum_.*|pod_uid|instance|job"
       }
     }
 
@@ -179,7 +180,22 @@ data:
     }
 
     prometheus.scrape "default" {
-      targets    = discovery.relabel.all_targets_with_address.output
+      targets    = discovery.relabel.pod_targets.output
+      forward_to = [prometheus.remote_write.prometheus.receiver, prometheus.remote_write.mimir.receiver]
+    }
+
+    // Nodes need their own scrape: kubelet only serves :10250 over HTTPS, and auth is
+    // per-component, so these targets cannot share the plaintext pod scrape. See #271.
+    prometheus.scrape "nodes" {
+      targets           = discovery.relabel.node_targets.output
+      scheme            = "https"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tls_config {
+        insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.remote_write.prometheus.receiver, prometheus.remote_write.mimir.receiver]
     }
 

--- a/docs/alloy.md
+++ b/docs/alloy.md
@@ -51,7 +51,9 @@ prometheus.remote_write "mimir" {
 }
 ```
 
-A single `prometheus.scrape "default"` block walks kubelet pod targets, nodes and services and forwards to both writers. Targets with `prometheus.io/scrape: "false"` get dropped during relabel.
+Two `prometheus.scrape` blocks feed both writers. `prometheus.scrape "default"` walks the node-local kubelet pod targets; targets with `prometheus.io/scrape: "false"` get dropped during relabel. `prometheus.scrape "nodes"` scrapes each node's kubelet over HTTPS with the ServiceAccount token, distributed across Alloy instances by clustering.
+
+Cluster-wide `role = "service"` discovery was removed in [#271](https://github.com/saidsef/grafana-loki-on-k8s/issues/271). It re-scraped the same endpoints through the ClusterIP - round-robining across replicas, from every Alloy pod - and accounted for 48% of scraped samples while contributing no target the kubelet path did not already cover.
 
 Traces come in on OTLP, get K8s metadata attached, and are forwarded to Tempo unsampled:
 


### PR DESCRIPTION
Closes #271.

Alloy concatenated three discovery sources into one relabel block, two of which overlapped. `discovery.kubelet "pods"` already sees every pod on the node; `discovery.kubernetes "services"` then reached the same endpoints again through the ClusterIP.

## What the measurement said

Queried live Mimir before touching anything. The live ConfigMap is byte-identical to this repo's, so the numbers describe exactly the pipeline being changed.

```promql
sum(scrape_samples_scraped{source="services"}) / sum(scrape_samples_scraped)  = 0.4805
```

All 24 live Service targets resolve to a pod target on the same port. Zero unique contribution. The pod path covers strictly more - `argocd-gitlab-runner`, `cilium-agent`, `cilium-operator` and `external-secrets` have no Service target at all.

Both classes that could have been lost were checked and neither exists here:

- **Selector-less or external Services.** None. Every live Service target is backed by in-cluster pods.
- **Metrics ports not declared as a `containerPort`.** Seven such pod targets exist and all are `up=0`, but every one belongs to a workload already scraped on another port.

Full working in the [issue comment](https://github.com/saidsef/grafana-loki-on-k8s/issues/271#issuecomment-5158772985).

## The second copy was also wrong

Service targets are addressed at `<svc>.<ns>.svc:<port>`, so kube-proxy picked a random backing pod per scrape. `kube-dns.kube-system.svc:9153` fronts two CoreDNS pods, which made that one series hop between replicas with counters resetting at random. That is not a duplicate worth keeping.

## Node discovery never worked

Fixed here rather than left for later, since the pipeline was being split anyway. `role = "node"` addresses the kubelet at `:10250`, which only serves HTTPS, and the pipeline set no scheme and no auth - `sum(up{source=""})` has been `0` since it was added, emitting only the `up`/`scrape_*` synthetics.

Auth is per-component in Alloy, so node targets cannot share the plaintext pod scrape. They now get their own `discovery.relabel "node_targets"` and `prometheus.scrape "nodes"` with `scheme = "https"`, the ServiceAccount bearer token and `insecure_skip_verify`, mirroring what `discovery.kubelet "pods"` already does in the same file. `clustering { enabled = true }` is set because `discovery.kubernetes` is cluster-scoped, unlike the kubelet - without it, every Alloy pod would scrape every node.

## Changes

- Deleted `discovery.kubernetes "services"`, plus the two relabel rules only it could trigger: `source = "services"` and the `__meta_kubernetes_service_label_` labelmap. Neither can fire for kubelet or node targets.
- Renamed `discovery.relabel "all_targets_with_address"` to `pod_targets` - it is pod-only now and the old name was misleading.
- Moved the `node_hostname` / `zone` / `region` rules into the new node block. They read `__meta_kubernetes_node_label_*`, which only the node role emits. This also drops the `service_name="k8s//"` that node targets used to pick up from the pod-oriented rule.
- Updated `docs/alloy.md`, which asserted the removed behaviour.

RBAC is untouched. `services` is now unused by the config, but trimming it belongs in a dedicated least-privilege pass alongside the other unused resources.

## Worth knowing before merge

Fixing the node scrape adds a metrics source that has never produced data - several hundred kubelet series per node. Prometheus already scrapes the same `/metrics` via its own `kubernetes-nodes` job in `deployment/prometheus/cm.yml`, so node metrics will land in Prometheus twice under different `job`/`instance` labels. No collision, but genuine duplication. If that is unwanted, the follow-up is to drop the Prometheus job.

This repo does not deploy anything - the live stack comes from `k8s-kops.git` at `services/metrics-server`. The same change needs mirroring there.

## Verification

`alloy validate` passes against v1.18.0 on the rendered ConfigMap. A negative control with a bad component reference was rejected, confirming the validator actually resolves references.

Baseline for post-sync comparison: `cortex_ingester_memory_series` = 174,432, `count(up{source="kubelet_pods"} == 1)` = 29, no `cortex_discarded_samples_total` activity.

After sync:

```promql
sum(scrape_samples_scraped{source="services"})   # no data
count(up{source="kubelet_pods"} == 1)            # still 29
sum(up{source="nodes"})                          # 1, was 0
count by (instance) (up{source="nodes"})         # one series per node, proving clustering
sum(cortex_ingester_memory_series)               # below 174432
```
