### PR TITLE
fix(tempo): switch to classic histograms so collections stop aborting

### DIFF
--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -112,4 +112,7 @@ data:
           max_traces_per_user: 0
         metrics_generator:
           processors: [service-graphs, span-metrics, local-blocks, host-info]
-          generate_native_histograms: both
+          # `both` reaches an unguarded out-of-order init append that aborts whole
+          # collection cycles; `classic` keeps the series Grafana's service graph
+          # queries. See grafana/tempo#5945.
+          generate_native_histograms: classic


### PR DESCRIPTION
Closes #273.

Sets `generate_native_histograms: classic` in the Tempo metrics-generator overrides.

## Why

The generator has been failing roughly 9% of its 15s collection cycles with `collecting metrics failed` / `out of order sample`. The rejection is from Tempo's own Prometheus agent WAL, not Mimir.

When a histogram series is dropped from the registry after `stale_duration` and later reappears, the generator backfills a zero sample timestamped at the end of the previous minute. Three of the four places that do this tolerate an out-of-order rejection; the `_count` init inside `classicHistograms()` does not, so it returns before `Commit()` and the whole tick is thrown away - every generator metric, not just the offending series. That code path only runs under `both`. It is unguarded in 2.10.7, 3.0.2 and main, so upgrading is not a way out.

#273 has the full evidence, including the timestamp pattern that pins the failing append.

## Why classic and not native

`native` avoids the bug too and would cut cardinality, but Grafana's service graph queries `traces_service_graph_request_server_seconds_sum` and the service graph view queries `traces_spanmetrics_latency_bucket`. Neither exists in native mode, so both would go blank. `classic` routes the histograms through `histogram.go`, where all the init appends are guarded, and keeps every series Grafana asks for.

The trade is losing native histograms: back to one series per bucket, and remote write transfers the constituent series independently rather than as one composite sample.

## Verifying

After this is deployed, `tempo_metrics_generator_registry_collections_failed_total{error_type="out_of_order"}` should stop climbing, and the `registry.go` error should disappear from the pod logs.

## Note

This does not change the running cluster on its own. The `aws-metrics-server` ArgoCD app syncs from `k8s-kops.git`, path `services/metrics-server`, branch `master`. The same edit is needed there.
