### PR TITLE
fix(beyla): instrument workloads again and drop privileged mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [Beyla](https://grafana.com/docs/beyla/latest/) Grafana Beyla uses eBPF to automatically inspect application executables and the OS networking layer, and capture trace spans related to web transactions and Rate Errors Duration (RED) metrics for Linux HTTP/S and gRPC services. *All data capture occurs without any modifications to application code or configuration*.
 > [!WARNING]
-> [Beyla](https://grafana.com/docs/beyla/latest/security/) needs access to various Linux interfaces to instrument applications, loading eBPF programs, and managing network interface filters, these operations require elevated permissions.
+> [Beyla](https://grafana.com/docs/beyla/latest/security/) needs access to various Linux interfaces to instrument applications, load eBPF programs and manage network interface filters. It runs unprivileged here, with all capabilities dropped and eight added back explicitly, plus `hostPID`, `hostNetwork` and three host mounts. See [docs/beyla.md](./docs/beyla.md).
 
 [Promtail](https://grafana.com/docs/loki/latest/clients/promtail/) is an agent which ships the contents of local logs to a private Grafana Loki instance or Grafana Cloud.
 > [!NOTE]
@@ -109,7 +109,7 @@ VISUALIZATION QUERIES:
 
 DATA COLLECTION FLOW:
 =====================
-Applications → Beyla/Alloy/Promtail → Storage Backends → Grafana Dashboards
+Applications → Beyla/Alloy → Storage Backends → Grafana Dashboards
 
 GRAFANA DATASOURCES:
 ====================

--- a/deployment/alloy/cm.yml
+++ b/deployment/alloy/cm.yml
@@ -275,17 +275,9 @@ data:
         gc_frequency = "2m"
     }
 
-    // --- Pyroscope: pprof scraping + eBPF profiles from Beyla ---
-    // eBPF CPU profiles (all languages, no annotations required) arrive via
-    // otelcol.receiver.otlp and are forwarded directly to pyroscope.write above.
-    //
-    // pprof scraping (Go services): memory, cpu, goroutine are opt-in.
-    // Single-annotation shortcut: set profiles.grafana.com/port: "<n>" on a pod
-    // to enable all three types without per-type annotations.
-    // Per-type opt-out: profiles.grafana.com/<type>.scrape: "false".
-    // Block, mutex, fgprof remain fully opt-in (high overhead; require app-side setup).
-    // pyroscope.write silently drops profiles after 3 retries so Alloy stays
-    // healthy when Pyroscope is not deployed alongside this stack.
+    // --- Pyroscope: pprof scraping (Go services, opt-in) ---
+    // Beyla's eBPF profiles do not pass through here; they go straight to
+    // pyroscope:4040. See docs/pyroscope.md for the annotation contract.
 
     discovery.kubernetes "pyroscope_pods" {
       role = "pod"
@@ -332,11 +324,8 @@ data:
         replacement   = "$1"
       }
 
-      // Single-annotation shortcut: profiles.grafana.com/port: "<n>" without a
-      // per-type scrape annotation synthesises scrape=true for memory, cpu, goroutine.
-      // Regex fires only when the type-specific scrape annotation is absent (empty)
-      // and the global port annotation is a number, so explicit opt-out ("false") is
-      // preserved and explicit per-type opt-in ("true") is left unchanged.
+      // Regex matches only when the per-type annotation is absent, so an explicit
+      // "false" opt-out survives. See docs/pyroscope.md.
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_scrape",
                          "__meta_kubernetes_pod_annotation_profiles_grafana_com_port"]

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -1,5 +1,4 @@
 ---
-# Source: alloy/templates/controllers/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/deployment/beyla/cm.yml
+++ b/deployment/beyla/cm.yml
@@ -36,11 +36,12 @@ data:
         max_interval: 5m
         max_elapsed_time: 30s
     discovery:
+      # Globs, not regex. Regex syntax here silently instruments nothing.
       instrument:
-        - k8s_namespace: .
+        - k8s_namespace: "*"
           containers_only: true
       exclude_instrument:
-        - exe_path: ".*tempo.*|.*loki.*|.*prometheus.*|.*mimir.*|.*grafana.*"
+        - exe_path: "{*tempo*,*loki*,*prometheus*,*mimir*,*grafana*}"
     attributes:
       kubernetes:
         enable: true
@@ -73,13 +74,11 @@ data:
         - /metrics
       ignore_mode: traces
     metrics:
+      # application_service_graph omitted: Tempo owns the service graph. See #269.
       features:
         - application
-        # application_service_graph omitted: Beyla emits the same traces_service_graph_*
-        # names as Tempo's generator but with extra labels, and Grafana sums by
-        # (client, server), merging both. Tempo owns the service graph. See #269.
         - application_span_otel
-    # network: Memory and CPU usage increases as Beyla needs to generate more metrics from network traffic
+    # Disabled: a metric per flow costs materially more CPU and memory.
     network:
       enable: false
       print_flows: false

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -18,9 +18,10 @@ spec:
         app.kubernetes.io/name: beyla
         cluster: kubernetes
     spec:
+      # Privileges, host mounts and their rationale: see docs/beyla.md.
       serviceAccountName: beyla
-      hostPID: true           # <-- Important. Required in DaemonSet mode so Beyla can discover all monitored processes
-      hostNetwork: true       # <-- Important. Required in DaemonSet mode so Beyla can see all network packets
+      hostPID: true
+      hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
@@ -67,19 +68,23 @@ spec:
                 resourceFieldRef:
                   divisor: '1'
                   resource: limits.memory
+          # privileged: true would grant all of these implicitly and make
+          # enforce_sys_caps unable to fire. Keep the list explicit.
           securityContext:
             runAsUser: 0
-            privileged: true
             readOnlyRootFilesystem: true
             capabilities:
+              drop:
+                - ALL
               add:
-                - BPF                 # <-- Important. Required for most eBPF probes to function correctly.
-                - SYS_PTRACE          # <-- Important. Allows Beyla to access the container namespaces and inspect executables.
-                - NET_RAW             # <-- Important. Allows Beyla to use socket filters for http requests.
-                - CHECKPOINT_RESTORE  # <-- Important. Allows Beyla to open ELF files.
-                - DAC_READ_SEARCH     # <-- Important. Allows Beyla to open ELF files.
-                - PERFMON             # <-- Important. Allows Beyla to load BPF programs.
-                - NET_ADMIN           # <-- Important. Allows Beyla to inject HTTP and TCP context propagation information.
+                - BPF
+                - SYS_PTRACE
+                - NET_RAW
+                - CHECKPOINT_RESTORE
+                - DAC_READ_SEARCH
+                - PERFMON
+                - NET_ADMIN
+                - SYS_ADMIN
           resources:
             limits:
               cpu: 100m
@@ -91,10 +96,15 @@ spec:
             - mountPath: /etc/beyla/config
               name: beyla-config
             - name: cgroup
-              mountPath: /sys/fs/cgroup # <-- Important. Allows Beyla to monitor all newly sockets to track outgoing requests.
+              mountPath: /sys/fs/cgroup
               readOnly: true
             - name: tracefs
-              mountPath: /sys/kernel/tracing # <-- Important. Required from 3.28.0 for context propagation, which uses normal tracepoints.
+              mountPath: /sys/kernel/tracing
+            # Must resolve to a real bpffs, and Cilium mounts it after we may start,
+            # hence the propagation. Without it, pinned maps are silently disabled.
+            - name: bpffs
+              mountPath: /sys/fs/bpf
+              mountPropagation: HostToContainer
       volumes:
         - name: beyla-config
           configMap:
@@ -105,3 +115,7 @@ spec:
         - name: tracefs
           hostPath:
             path: /sys/kernel/tracing
+        - name: bpffs
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory

--- a/deployment/prometheus/cm.yml
+++ b/deployment/prometheus/cm.yml
@@ -119,9 +119,6 @@ data:
       evaluation_interval: 1m
       scrape_interval: 1m
       scrape_timeout: 10s
-    # remote_write:
-    # - name: mimir
-    #   url: http://mimir/api/v1/push
     rule_files:
     - /etc/config/recording_rules.yml
     - /etc/config/alerting_rules.yml

--- a/deployment/promtail/cm.yml
+++ b/deployment/promtail/cm.yml
@@ -32,18 +32,6 @@ data:
       relabel_configs:
         - source_labels: ['__journal__systemd_unit']
           target_label: 'unit'
-    # - job_name: system
-    #   system:
-    #     json: false
-    #     max_age: 24h
-    #     path: /var/log/*log
-    #   static_configs:
-    #   - targets:
-    #       - localhost
-    #     labels:
-    #       job: system-logs
-    #       __path__: /var/log/*log
-
     - job_name: pod-logs
       kubernetes_sd_configs:
         - role: pod

--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -58,9 +58,6 @@ data:
       storage:
         path: /var/tempo/generator/wal
         remote_write:
-          # - url: http://prometheus-server/api/v1/write
-          #   send_exemplars: true
-          #   name: prometheus
           - url: http://mimir/api/v1/push
             send_exemplars: true
             name: mimir
@@ -112,7 +109,5 @@ data:
           max_traces_per_user: 0
         metrics_generator:
           processors: [service-graphs, span-metrics, local-blocks, host-info]
-          # `both` reaches an unguarded out-of-order init append that aborts whole
-          # collection cycles; `classic` keeps the series Grafana's service graph
-          # queries. See grafana/tempo#5945.
+          # `both` aborts whole collection cycles. See grafana/tempo#5945.
           generate_native_histograms: classic

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Reference material for this repository. The root [`README.md`](../README.md) cov
 ## Available documents
 
 - [Alloy](./alloy.md) - the DaemonSet collector that fans telemetry out to Loki, Prometheus, Mimir and Tempo.
+- [Beyla](./beyla.md) - eBPF auto-instrumentation; privileges, host mounts and the glob-based discovery rules.
 - [Loki](./loki.md) - logs backend, single-binary mode on local filesystem.
 - [Mimir](./mimir.md) - long-term metrics store, default Grafana data source.
 - [Prometheus](./prometheus.md) - short-term metrics and rule evaluation, runs alongside Mimir.

--- a/docs/alloy.md
+++ b/docs/alloy.md
@@ -99,7 +99,9 @@ Profiling data reaches Pyroscope through two complementary paths.
 
 ### eBPF CPU profiling via Beyla (all services, no annotations)
 
-When Pyroscope is included in the kustomization, a patch is applied to Beyla's ConfigMap that activates `otel_profiles_export`. Beyla uses eBPF perf events to collect CPU flame graphs from every process it discovers — any language, zero application changes. Profiles are pushed directly to Pyroscope at `http://pyroscope:4040` with a 30-second retry window before dropping. When Pyroscope is not deployed (commented out of `deployment/kustomization.yml`), the patch is never applied and Beyla has no profiling overhead.
+[Beyla](./beyla.md)'s ConfigMap enables `otel_profiles_export` unconditionally. Beyla uses eBPF perf events to collect CPU flame graphs from every process it discovers — any language, zero application changes. Profiles go straight to Pyroscope at `http://pyroscope:4040` with a 30-second retry window before dropping; they never traverse Alloy, whose `otelcol.receiver.otlp` carries no profiles signal. Commenting Pyroscope out of `deployment/kustomization.yml` does not stop Beyla profiling — it keeps collecting and drops each batch once the retry window expires.
+
+Beyla runs as its own DaemonSet rather than via Alloy's `beyla.ebpf` component; [docs/beyla.md](./beyla.md) explains why.
 
 ### pprof scraping via Alloy (Go services, opt-in)
 

--- a/docs/beyla.md
+++ b/docs/beyla.md
@@ -1,0 +1,90 @@
+# Beyla
+
+Beyla is the eBPF auto-instrumentation agent. It inspects application executables and the OS networking layer directly, producing RED metrics and trace spans for HTTP/S and gRPC services without touching application code. Manifests live in [`deployment/beyla/`](../deployment/beyla/).
+
+It runs as its own DaemonSet rather than inside [Alloy](./alloy.md). See [Why not `beyla.ebpf` in Alloy](#why-not-beylaebpf-in-alloy).
+
+## What it runs
+
+- DaemonSet, image `docker.io/grafana/beyla:3.30.0`, one pod per node.
+- `hostPID: true` so Beyla can see and inspect processes in other containers' PID namespaces. Mandatory in DaemonSet mode.
+- `hostNetwork: true` with `dnsPolicy: ClusterFirstWithHostNet`, required for the network-level context propagation described below.
+- Health, readiness and liveness on port 9090 (`/healthz`).
+- Resources: requests 50m CPU / 512Mi, limits 100m CPU / 768Mi.
+- Exports metrics and traces to Alloy at `alloy:4317`, and profiles straight to `pyroscope:4040`.
+
+## Privileges
+
+Beyla runs unprivileged: `privileged: true` is deliberately absent, because it grants every capability, which would make the explicit list below decorative and stop `enforce_sys_caps: true` from ever firing. Instead all capabilities are dropped and eight are added back:
+
+| Capability | Why |
+|---|---|
+| `BPF` | Required for most eBPF probes to function. |
+| `SYS_PTRACE` | Access other containers' namespaces and inspect executables. |
+| `NET_RAW` | Socket filters for HTTP requests. |
+| `CHECKPOINT_RESTORE` | Open ELF files. |
+| `DAC_READ_SEARCH` | Open ELF files. |
+| `PERFMON` | Load BPF programs. |
+| `NET_ADMIN` | Inject HTTP and TCP context propagation information. |
+| `SYS_ADMIN` | User-space probes, and any host with `kernel.perf_event_paranoid >= 3`. |
+
+`SYS_ADMIN` is not optional on the production node: it reports `perf_event_paranoid = 4`. Dropping `privileged` without adding `SYS_ADMIN` would stop Beyla loading probes. That node also sets `unprivileged_bpf_disabled = 1`, which makes `CAP_BPF` mandatory.
+
+`readOnlyRootFilesystem: true` and `runAsUser: 0` are both required — the host bpffs is mounted `mode=700`, so only root can traverse it.
+
+## Host mounts
+
+| Mount | Why |
+|---|---|
+| `/sys/fs/cgroup` (read-only) | Track newly created sockets for outgoing requests. |
+| `/sys/kernel/tracing` | Required from Beyla 3.28.0 — context propagation now uses normal tracepoints. |
+| `/sys/fs/bpf` | Must be a **real bpffs**, not just a directory. |
+
+The bpffs mount uses `mountPropagation: HostToContainer`, and that is load-bearing. Beyla defaults `bpf_fs_path` to `/sys/fs/bpf` and calls `MkdirAll` on `/sys/fs/bpf/otel`. If that path is plain sysfs rather than a mounted bpffs, the call fails, and Beyla logs a warning and then **silently disables every pinned map** — which it documents as disabling the log enricher and profile correlation. It does not crash.
+
+On the production node the bpffs is mounted by *Cilium*, not by systemd (`sys-fs-bpf.mount` is inactive). Because a pod provides the mount, boot ordering against the Beyla DaemonSet is not guaranteed. Without `HostToContainer`, a Beyla that starts before cilium-agent captures the read-only sysfs view and never sees the bpffs that appears later.
+
+If profiles or correlation go missing, check for this in the Beyla logs:
+
+```
+creating OTEL namespace in bpffs failed (is bpffs mounted?)
+```
+
+## Discovery
+
+`discovery.instrument` and `discovery.exclude_instrument` match by **glob**, not regex. The older `discovery.services` / `exclude_services` keys are regex — the two families differ, and mixing them up fails silently: Beyla instruments nothing, logs nothing at `WARN`, and Alloy's `otelcol_receiver_accepted_*` counters simply stay at zero.
+
+```yaml
+discovery:
+  instrument:
+    - k8s_namespace: "*"      # "*" matches all namespaces; "." would match only a literal "."
+      containers_only: true
+  exclude_instrument:
+    - exe_path: "{*tempo*,*loki*,*prometheus*,*mimir*,*grafana*}"
+```
+
+The stack's own backends are excluded to avoid instrumenting the observability plumbing. Beyla additionally self-excludes by default (`*beyla`, `*alloy`, `*otelcol`, `*obi` and similar).
+
+To diagnose a silent no-op, set `log_level: DEBUG` and look for:
+
+```
+msg="metadata does not match" attr=k8s_namespace value=<namespace>
+```
+
+## Metrics features
+
+`application` and `application_span_otel` are enabled. `application_service_graph` is deliberately omitted: Beyla emits the same `traces_service_graph_*` metric names as Tempo's generator but with extra labels, and Grafana sums by `(client, server)`, merging the two into one misleading series. [Tempo](./tempo.md) owns the service graph. See #269.
+
+`network` is disabled. Network-level metrics require Beyla to generate a metric per flow, which raises CPU and memory materially, and the RED metrics above already cover the questions being asked of this stack.
+
+## Profiles
+
+`otel_profiles_export` is enabled unconditionally and pushes to `pyroscope:4040` over OTLP gRPC. This bypasses Alloy entirely — Alloy's `otelcol.receiver.otlp` carries no profiles signal. If [Pyroscope](./pyroscope.md) is removed from the kustomization, Beyla keeps collecting and drops each batch after its 30-second retry window; it does not stop profiling. See [Pyroscope](./pyroscope.md) for the full profiling picture.
+
+## Why not `beyla.ebpf` in Alloy
+
+Alloy ships a `beyla.ebpf` component that would fold this DaemonSet into the Alloy one. It is not used here:
+
+- Alloy's embedded Beyla is several versions behind the standalone image. The tracefs mount above, needed from 3.28.0, is not in it.
+- The component requires Alloy to run with administrative privileges (or the same capability list), plus `hostPID: true` and an **Unconfined** AppArmor profile. Alloy currently runs unprivileged with all capabilities dropped, and it carries every log, metric, trace and profile pipeline in the stack — a much larger blast radius.
+- Beyla needs `hostNetwork: true` for context propagation, which would collide with Alloy's ports 4317, 4318 and 12345 on every node.

--- a/docs/pyroscope.md
+++ b/docs/pyroscope.md
@@ -41,7 +41,7 @@ Cluster membership is via memberlist gossip using DNS SRV lookup on the service.
 
 Profiles arrive from two sources:
 
-**Beyla eBPF** — when Pyroscope is included in the kustomization, Beyla's ConfigMap is patched to enable `otel_profiles_export`. Beyla collects CPU flame graphs from every process via eBPF perf events and pushes them directly to `http://pyroscope:4040`. No application changes or annotations required. If Pyroscope is later removed from the kustomization, the patch is not applied and Beyla stops profiling.
+**Beyla eBPF** — [Beyla](./beyla.md)'s ConfigMap enables `otel_profiles_export` unconditionally. Beyla collects CPU flame graphs from every process via eBPF perf events and pushes them directly to `http://pyroscope:4040`, bypassing Alloy. No application changes or annotations required. If Pyroscope is later removed from the kustomization, Beyla keeps profiling and drops each batch once its 30-second retry window expires.
 
 **Alloy pprof scraping** — for Go services, Alloy pulls pprof endpoints. A single annotation enables memory, CPU, and goroutine profiling:
 
@@ -92,4 +92,4 @@ That is the path Grafana uses to jump from a slow span straight to the matching 
 - Pyroscope stores and serves profiles. Collection is handled by Alloy (pprof) and Beyla (eBPF).
 - Trace-to-profile links from [Tempo](./tempo.md) are what tie profiles to the rest of the data.
 - Any service shows up in CPU flame graphs automatically via Beyla eBPF. Go services get richer heap and goroutine profiles by adding pprof annotations.
-- Pyroscope is optional. When not deployed, Alloy drops pprof profiles after a short retry window, and the Beyla patch is not applied so there is no wasted profiling overhead.
+- Pyroscope is optional, but not free to omit. Alloy drops pprof profiles after a short retry window, and Beyla carries on collecting eBPF profiles and drops each batch after 30 seconds of retries.


### PR DESCRIPTION
Closes #276.

Beyla was selecting no processes, so the whole DaemonSet was a no-op. Fixes that, makes its capability list mean something, gives it a real bpffs, and moves the rationale out of the manifests into a doc.

## Discovery

`discovery.instrument` and `exclude_instrument` match by glob. We passed regex, so `k8s_namespace: .` matched only a literal `"."`:

```diff
-        - k8s_namespace: .
+        - k8s_namespace: "*"
-        - exe_path: ".*tempo.*|.*loki.*|.*prometheus.*|.*mimir.*|.*grafana.*"
+        - exe_path: "{*tempo*,*loki*,*prometheus*,*mimir*,*grafana*}"
```

## Privileges

Dropped `privileged: true` and added `drop: [ALL]`. Previously `privileged` granted every capability implicitly, so the annotated list underneath it did nothing and `enforce_sys_caps: true` could never fire.

Added `SYS_ADMIN`, which is not cosmetic: the production node reports `kernel.perf_event_paranoid = 4`, and Beyla needs `SYS_ADMIN` at 3 or above. Removing `privileged` without it would have stopped Beyla loading probes. That node also sets `kernel.unprivileged_bpf_disabled = 1`, so `CAP_BPF` is required too.

## bpffs

Mounted the host `/sys/fs/bpf` with `mountPropagation: HostToContainer`. Beyla creates `/sys/fs/bpf/otel`; if the path is plain sysfs the mkdir fails and it silently disables all pinned maps, which upstream documents as losing the log enricher and profile correlation.

The propagation mode matters here specifically. Cilium provides the bpffs on our nodes, not systemd (`sys-fs-bpf.mount` is inactive), so the mount can appear after Beyla starts. Without propagation a Beyla that wins the race is stuck on a read-only sysfs view.

## Docs and comments

Added `docs/beyla.md`. Beyla was the only deployed component without a doc, which is why its manifests had collected the most inline comments - 13 `# <--` annotations on the DaemonSet alone. All of that now lives in the doc, and the manifests keep only short reason-style comments.

Corrected a path that never existed: the Alloy config and both the Alloy and Pyroscope docs described eBPF profiles arriving via `otelcol.receiver.otlp` and being forwarded to `pyroscope.write`, and a kustomize patch that toggles `otel_profiles_export`. That receiver has no profiles signal, Beyla pushes straight to `pyroscope:4040`, and there is no patch in any kustomization. Removing Pyroscope does not stop Beyla profiling.

Also removed four blocks of commented-out config (Prometheus `remote_write`, Tempo's prometheus `remote_write`, Promtail's `system` scrape job) and a stale Helm provenance line.

## Testing

On a kind cluster with the full stack plus an nginx workload:

- Before, at DEBUG: `msg="metadata does not match" attr=k8s_namespace value=monitoring`. After the glob change, nginx passes the match and reaches the exclusion checks.
- Beyla runs `1/1 Ready` with 0 restarts unprivileged, and `enforce_sys_caps: true` does not abort, so the capability set is sufficient.
- `mkdir /sys/fs/bpf/otel` fails on sysfs, succeeds once a real bpffs is mounted. After mounting one on the host post-start, the container's mountinfo showed the bpffs stacked over the sysfs bind, confirming `HostToContainer` behaves as intended.
- `type: Directory` did not block scheduling.
- `kubectl kustomize` renders clean and `alloy fmt` accepts the River config.

End-to-end span export could not be confirmed on kind - `traceAttacher` never attaches on Docker Desktop's linuxkit kernel, which looks like an environment limit rather than config.
