### PR TITLE
chore(deps): upgrade stack images and migrate Tempo to 3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ALLOY_IMAGE    ?= docker.io/grafana/alloy:v1.18.0
+ALLOY_IMAGE    ?= docker.io/grafana/alloy:v1.18.1
 KIND_CLUSTER   ?= loki-stack
 KUBE_NAMESPACE ?= monitoring
 

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -26,7 +26,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.18.0
+          image: docker.io/grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -25,22 +25,26 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
-          image: docker.io/grafana/beyla:3.30.0
+          image: docker.io/grafana/beyla:3.32.0
           imagePullPolicy: IfNotPresent
           ports:
           - name: health
             containerPort: 9090
             protocol: TCP
+          # Beyla 3.31.0 binds /healthz to loopback only and ignores health_check.listen_address.
+          # hostNetwork puts that loopback on the node, so the kubelet reaches it at 127.0.0.1.
           readinessProbe:
             httpGet:
               path: /healthz
               port: 9090
+              host: 127.0.0.1
             initialDelaySeconds: 10
             periodSeconds: 15
           livenessProbe:
             httpGet:
               path: /healthz
               port: 9090
+              host: 127.0.0.1
             initialDelaySeconds: 30
             periodSeconds: 30
           env:

--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:13.1.1
+        image: docker.io/grafana/grafana:13.1.3
         imagePullPolicy: IfNotPresent
         env:
         - name: GOMAXPROCS

--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -30,7 +30,7 @@ spec:
         runAsUser: 10001
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.7.4
+          image: docker.io/grafana/loki:3.7.6
           imagePullPolicy: IfNotPresent
           args:
             - -target=all

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v3.13.1
+          image: docker.io/prom/prometheus:v3.13.2
           imagePullPolicy: IfNotPresent
           env:
             - name: GOMAXPROCS

--- a/deployment/pyroscope/deployment.yml
+++ b/deployment/pyroscope/deployment.yml
@@ -27,7 +27,7 @@ spec:
         runAsUser: 10001
       containers:
       - name: pyroscope
-        image: docker.io/grafana/pyroscope:2.2.0
+        image: docker.io/grafana/pyroscope:2.2.1
         imagePullPolicy: IfNotPresent
         args:
           - "-config.file=/etc/pyroscope/config.yaml"

--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -10,7 +10,17 @@ data:
     multitenancy_enabled: false
     usage_report:
       reporting_enabled: false
-    compactor:
+    # Tempo 3.0 replaced the compactor with the backend scheduler/worker pair.
+    # Both carry the retention window; the 3.0 default is 336h.
+    backend_scheduler:
+      provider:
+        compaction:
+          compaction:
+            block_retention: 48h
+            compacted_block_retention: 1h
+            compaction_cycle: 1h
+            compaction_window: 2h
+    backend_worker:
       compaction:
         block_retention: 48h
         compacted_block_retention: 1h
@@ -43,9 +53,6 @@ data:
             - http.method
             - http.request.method
 
-        local_blocks:
-          filter_server_spans: true
-          flush_to_storage: true
         host_info:
           host_identifiers:
             - k8s.node.name
@@ -53,8 +60,6 @@ data:
           metric_name: traces_host_info
         span_metrics:
           enable_target_info: true
-      traces_storage:
-        path: /var/tempo/generator/traces
       storage:
         path: /var/tempo/generator/wal
         remote_write:
@@ -93,7 +98,9 @@ data:
       trace:
         backend: local
         block:
-          version: vParquet4
+          # Opt-in; 3.0 still defaults to vParquet4. Adds dedicated columns for
+          # integers and events, and the span:childCount intrinsic.
+          version: vParquet5
           bloom_filter_false_positive: .05
         local:
           path: /var/tempo/traces
@@ -108,6 +115,6 @@ data:
         ingestion:
           max_traces_per_user: 0
         metrics_generator:
-          processors: [service-graphs, span-metrics, local-blocks, host-info]
+          processors: [service-graphs, span-metrics, host-info]
           # `both` aborts whole collection cycles. See grafana/tempo#5945.
           generate_native_histograms: classic

--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -26,7 +26,7 @@ spec:
         - -generator.instance-id=$(POD_IP)
         - -log.level=warn
         - -config.expand-env=true
-        image: docker.io/grafana/tempo:2.10.3
+        image: docker.io/grafana/tempo:3.0.3
         imagePullPolicy: IfNotPresent
         name: tempo
         env:
@@ -73,18 +73,10 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: tempo-conf
+        # 3.0 adds live-store and backend-scheduler paths under /var/tempo, so the
+        # whole tree is mounted rather than per-component subPaths.
         - name: tempo-storage
-          mountPath: /var/tempo/wal
-          subPath: wal
-        - name: tempo-storage
-          mountPath: /var/tempo/traces
-          subPath: traces
-        - name: tempo-storage
-          mountPath: /var/tempo/generator/wal
-          subPath: generator
-        - name: tempo-storage
-          mountPath: /var/tempo/generator/traces
-          subPath: local-traces
+          mountPath: /var/tempo
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false

--- a/docs/alloy.md
+++ b/docs/alloy.md
@@ -6,7 +6,7 @@ This stack uses Alloy in place of Promtail. The Promtail directory is still in t
 
 ## What it runs
 
-- DaemonSet, image `docker.io/grafana/alloy:v1.18.0`.
+- DaemonSet, image `docker.io/grafana/alloy:v1.18.1`.
 - Args: `run /etc/alloy/config.alloy --storage.path=/tmp/alloy --server.http.listen-addr=$(POD_IP):12345 --server.http.ui-path-prefix=/ --stability.level=public-preview --feature.community-components.enabled --cluster.enabled=true --cluster.name=$(CLUSTER_NAME) --cluster.wait-for-size=1`.
 - `CLUSTER_NAME` is read from the pod label `cluster` via the downward API, so it's set in the DaemonSet pod template rather than hardcoded in the args.
 - Ports: 12345 (HTTP UI and self metrics), 4317 (OTLP gRPC), 4318 (OTLP HTTP).

--- a/docs/beyla.md
+++ b/docs/beyla.md
@@ -6,10 +6,10 @@ It runs as its own DaemonSet rather than inside [Alloy](./alloy.md). See [Why no
 
 ## What it runs
 
-- DaemonSet, image `docker.io/grafana/beyla:3.30.0`, one pod per node.
+- DaemonSet, image `docker.io/grafana/beyla:3.32.0`, one pod per node.
 - `hostPID: true` so Beyla can see and inspect processes in other containers' PID namespaces. Mandatory in DaemonSet mode.
 - `hostNetwork: true` with `dnsPolicy: ClusterFirstWithHostNet`, required for the network-level context propagation described below.
-- Health, readiness and liveness on port 9090 (`/healthz`).
+- Health, readiness and liveness on port 9090 (`/healthz`), probed at `127.0.0.1`. Beyla 3.31.0 began binding this endpoint to loopback only and ignores `health_check.listen_address`; `hostNetwork` puts that loopback on the node, so the kubelet can still reach it.
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 768Mi.
 - Exports metrics and traces to Alloy at `alloy:4317`, and profiles straight to `pyroscope:4040`.
 

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -6,7 +6,7 @@ The cross-data-source linking (logs to traces, traces to logs / metrics / profil
 
 ## What it runs
 
-- Deployment, single replica, image `docker.io/grafana/grafana:13.0.1`.
+- Deployment, single replica, image `docker.io/grafana/grafana:13.1.3`.
 - Port: 3000 (HTTP). Service `grafana` exposes the same port.
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 768Mi. `GOMAXPROCS` and `GOMEMLIMIT` are bound to those limits via `resourceFieldRef`.
 - Storage: 4 Gi emptyDir at `/var/lib/grafana`, split by subPath into `grafana` (state), `dashboards` (provisioned dashboards) and `tmp`.

--- a/docs/loki.md
+++ b/docs/loki.md
@@ -6,7 +6,7 @@ It is single tenant (`auth_enabled: false`), no replication, no external ring. A
 
 ## What it runs
 
-- StatefulSet, single replica, image `docker.io/grafana/loki:3.7.2`.
+- StatefulSet, single replica, image `docker.io/grafana/loki:3.7.6`.
 - Args: `-target=all -config.file=/etc/loki/loki.yaml`.
 - Port: 3100 (HTTP). Service `loki` exposes the same port.
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 768Mi.

--- a/docs/mimir.md
+++ b/docs/mimir.md
@@ -4,7 +4,7 @@ Mimir is the long-term metrics store. It runs in single-binary mode (`target: al
 
 ## What it runs
 
-- StatefulSet, single replica, image `docker.io/grafana/mimir:3.0.6`.
+- StatefulSet, single replica, image `docker.io/grafana/mimir:3.1.4`.
 - Args (besides `-config.file=/conf/mimir.yaml`): `-auth.multitenancy-enabled=false -auth.no-auth-tenant=anonymous -compactor.blocks-retention-period=15d -distributor.ha-tracker.enable-for-all-users=true -querier.cardinality-analysis-enabled=true -blocks-storage.storage-prefix=blocks -ingester.out-of-order-time-window=15m -log.format=json -log.level=warn`.
 - Ports: 8080 (HTTP, exposed on the Service as port 80), 9095 (gRPC).
 - Resources: requests 100m CPU / 512Mi, limits 100m CPU / 768Mi.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -6,7 +6,7 @@ The `remote_write` to Mimir is intentionally commented out. Alloy writes to both
 
 ## What it runs
 
-- Deployment, single replica, image `docker.io/prom/prometheus:v3.11.3`.
+- Deployment, single replica, image `docker.io/prom/prometheus:v3.13.2`.
 - Args: `--storage.tsdb.retention.time=15d --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus/data/ --web.enable-remote-write-receiver --web.enable-otlp-receiver --web.enable-lifecycle --enable-feature=concurrent-rule-eval,promql-experimental-functions,exemplar-storage,promql-per-step-stats,native-histograms --log.level=warn --log.format=json`.
 - Port: 9090 (exposed on the Service `prometheus-server` as port 80).
 - Resources: requests 100m CPU / 512Mi, limits 150m CPU / 894Mi.

--- a/docs/pyroscope.md
+++ b/docs/pyroscope.md
@@ -4,7 +4,7 @@ Pyroscope is the continuous-profiling backend. Profile scraping is handled by [A
 
 ## What it runs
 
-- Deployment, single replica, image `docker.io/grafana/pyroscope:2.10.5`.
+- Deployment, single replica, image `docker.io/grafana/pyroscope:2.2.1`.
 - Args: `-config.file=/etc/pyroscope/config.yaml -runtime-config.file=/etc/pyroscope/overrides/overrides.yaml -log.level=info`. All other configuration is in `config.yaml` — log level is the one flag Pyroscope does not expose in the config file.
 - Ports: 4040 (HTTP, ingest and query), 9095 (gRPC), 7946 (memberlist).
 - Resources: requests 100m CPU / 512Mi, limits 200m CPU / 768Mi.

--- a/docs/tempo.md
+++ b/docs/tempo.md
@@ -6,11 +6,11 @@ Beyond storing spans, it runs a `metrics_generator` that converts spans into RED
 
 ## What it runs
 
-- StatefulSet, single replica, image `docker.io/grafana/tempo:2.10.3`.
+- StatefulSet, single replica, image `docker.io/grafana/tempo:3.0.3`.
 - Args: `-config.file=/conf/tempo.yaml -config.expand-env=true -generator.instance-id=$(POD_IP) -log.level=warn`.
 - Ports: 3100 (HTTP query), 9095 (gRPC), 4317 (OTLP gRPC), 4318 (OTLP HTTP), 14250 (Jaeger gRPC), 14268 (Jaeger Thrift HTTP), 6831 / 6832 (Jaeger Thrift UDP), 9411 (Zipkin).
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 896Mi.
-- Storage: single 10 Gi emptyDir split across `/var/tempo/wal`, `/var/tempo/traces`, `/var/tempo/generator/wal`, `/var/tempo/generator/traces` via subPaths.
+- Storage: single 10 Gi emptyDir mounted at `/var/tempo`, holding the WAL, blocks, generator WAL and live-store data.
 - Security: read-only root filesystem, all caps dropped, no privilege escalation.
 - A headless service (`tempo-headless`) exists alongside the ClusterIP service to satisfy the StatefulSet governing service requirement.
 
@@ -43,14 +43,16 @@ distributor:
         http: { endpoint: 0.0.0.0:4318 }
 ```
 
-Local filesystem, vParquet4 blocks:
+Local filesystem, vParquet5 blocks. Tempo 3.0 still defaults to vParquet4, so this is opt-in.
+vParquet5 adds dedicated columns for integer and event attributes and the `span:childCount`
+intrinsic. Older blocks stay readable, and new blocks are written in the new format:
 
 ```yaml
 storage:
   trace:
     backend: local
     block:
-      version: vParquet4
+      version: vParquet5
       bloom_filter_false_positive: .05
     local:
       path: /var/tempo/traces
@@ -58,10 +60,20 @@ storage:
       path: /var/tempo/wal
 ```
 
-Compaction is aggressive given the small storage budget, blocks live 48 hours:
+Compaction is aggressive given the small storage budget, blocks live 48 hours. Tempo 3.0
+replaced the compactor with a backend scheduler that hands jobs to a backend worker, so the
+same retention is set on both. Without it the 3.0 default of 336h applies:
 
 ```yaml
-compactor:
+backend_scheduler:
+  provider:
+    compaction:
+      compaction:
+        block_retention: 48h
+        compacted_block_retention: 1h
+        compaction_cycle: 1h
+        compaction_window: 2h
+backend_worker:
   compaction:
     block_retention: 48h
     compacted_block_retention: 1h
@@ -69,14 +81,14 @@ compactor:
     compaction_window: 2h
 ```
 
-Metrics-generator ring rides on memberlist, four processors enabled:
+Metrics-generator ring rides on memberlist, three processors enabled:
 
 ```yaml
 overrides:
   defaults:
     metrics_generator:
-      processors: [service-graphs, span-metrics, local-blocks, host-info]
-      generate_native_histograms: both
+      processors: [service-graphs, span-metrics, host-info]
+      generate_native_histograms: classic
 ```
 
 `host-info` emits a `traces_host_info` gauge keyed on `k8s.node.name` and `host.id`. `service-graphs` is tuned with a 60s wait to allow time for cross-node span pairs that arrive via tail sampling, plus peer_attributes and dimensions for richer label coverage. The generator writes metrics to Mimir:
@@ -142,5 +154,5 @@ The generated span metrics arrive in Mimir and Prometheus, where Grafana reads t
 ## How it fits the stack
 
 - Spans in from [Alloy](./alloy.md), metrics out to [Prometheus](./prometheus.md) and [Mimir](./mimir.md), correlated jumps to [Loki](./loki.md) and [Pyroscope](./pyroscope.md) handled by the data-source config.
-- The `local-blocks` processor is what makes TraceQL metrics queries work.
+- TraceQL metrics queries are served from the live-store and backend blocks. Tempo 3.0 removed the `local-blocks` processor that previously backed them, and only reads RF1 blocks written by 3.0, so coverage starts at the upgrade. Storage is an emptyDir here, so nothing predates it anyway.
 - Single replica means HA is not a goal here. The 10 Gi emptyDir caps how much history fits, the 48-hour retention is sized for it.


### PR DESCRIPTION
Fixes #278.

Grafana moves to 13.1.3, Loki to 3.7.6, Alloy to v1.18.1, Prometheus to v3.13.2, Pyroscope to 2.2.1, Beyla to 3.32.0 and Tempo to 3.0.3. Mimir was already on 3.1.4 and is untouched. Every tag was checked against the registry before use.

## Tempo 3.0

The configuration was migrated with `tempo-cli migrate config` rather than by hand, then adjusted where the tool's assumptions did not apply. Retention is restated on both `backend_scheduler` and `backend_worker`, because the 3.0 default of 336h would otherwise replace the 48 hours this deployment is sized for. The `local_blocks` processor, its `traces_storage` path and the `local-blocks` entry in the processor list are removed, since 3.0 no longer has them.

The four per-component subPath mounts are replaced by a single mount of the volume at `/var/tempo`. The live store and backend scheduler write to paths beneath it that the old mounts did not cover, and with a read-only root filesystem those writes would fail at startup.

The migration tool also emits `compaction_disabled: true`, which exists to stop a 3.0 deployment competing with a 2.x one still running alongside it. This is a straight replacement, so that is left out.

Blocks are written as vParquet5. Tempo 3.0 supports it but still defaults to vParquet4, so it is opt-in. It adds dedicated columns for integer and event attributes and the `span:childCount` intrinsic, and older blocks remain readable.

## Beyla

Since 3.31.0 Beyla binds `/healthz` to `127.0.0.1` and ignores `health_check.listen_address`, which is read from the config but never reaches the listener. Probing the pod address therefore returns connection refused, and the kubelet restarts the container on the liveness probe, so the DaemonSet never becomes ready. `hostNetwork` places that loopback on the node, so both probes now set `host: 127.0.0.1`.

## Verification

`make validate` passes: the Alloy configuration formats cleanly against v1.18.1 and the manifests render.

The full stack was deployed to a kind cluster. All eight workloads reach ready with no restarts on the new images. Tempo reports vParquet5 and 48h retention in its effective configuration, and a flushed block's metadata confirms the vParquet5 format with integer dedicated columns present. Traces pushed over OTLP are retrievable by ID and through TraceQL search, and TraceQL metrics return correct per-service counts, which is the path that previously depended on the removed local-blocks processor.

Service graph output was checked rather than assumed, since it is the part most exposed to the metrics-generator changes. A client and server span pair produces `traces_service_graph_request_total` in Mimir, and the `sum by (client, server)` query Grafana issues for the node graph returns the expected edge.

Beyla 3.32.0 was confirmed unready under the previous probes and ready under the loopback probes, on the same cluster and configuration.