### PR TITLE
fix(tempo): restore service graph by dropping virtual node label

### DIFF
--- a/deployment/tempo/cm.yml
+++ b/deployment/tempo/cm.yml
@@ -40,7 +40,9 @@ data:
           wait: 60s
           max_items: 10000
           enable_client_server_prefix: true
-          enable_virtual_node_label: true
+          # Suppresses virtual-node edges entirely on 3.0.3; every edge here is one
+          # (client spans to uninstrumented peers), so enabling it empties the graph.
+          # enable_virtual_node_label: true
           enable_messaging_system_latency_histogram: true
           peer_attributes:
             - peer.service

--- a/docs/tempo.md
+++ b/docs/tempo.md
@@ -91,7 +91,11 @@ overrides:
       generate_native_histograms: classic
 ```
 
-`host-info` emits a `traces_host_info` gauge keyed on `k8s.node.name` and `host.id`. `service-graphs` is tuned with a 60s wait to allow time for cross-node span pairs that arrive via tail sampling, plus peer_attributes and dimensions for richer label coverage. The generator writes metrics to Mimir:
+`host-info` emits a `traces_host_info` gauge keyed on `k8s.node.name` and `host.id`. `service-graphs` is tuned with a 60s wait to allow time for cross-node span pairs, plus peer_attributes and dimensions for richer label coverage.
+
+`enable_virtual_node_label` is deliberately left off. On 3.0.3 it stops virtual-node edges being emitted at all, and every edge here is a virtual node - client spans naming an uninstrumented peer through `peer.service`, which is what produces the `client=<service>` to `server=elasticsearch` edges. Turning it on empties the service graph while span metrics carry on unaffected, so the generator looks healthy.
+
+The generator writes metrics to Mimir:
 
 ```yaml
 metrics_generator:


### PR DESCRIPTION
Fixes #280.

`enable_virtual_node_label` comes out of the `service_graphs` block. On Tempo 3.0.3 it stops virtual-node edges being emitted at all - the edges are created, the processor reports itself active, and no `traces_service_graph_*` series ever reaches the registry.

A single-variable comparison isolates it. Holding every other `service_graphs` option constant, `wait` included, and varying only this one: with the option removed all seven series appear inside a single wait window, labelled `connection_type=virtual_node`; with it set, sixteen edges over two minutes produce nothing. Matched client/server spans are emitted either way, so the fault only surfaces where edges depend on the virtual-node path - a `client` span naming an uninstrumented callee through `peer.service`. Where services talk to datastores rather than to each other, that is every edge, and the graph vanishes rather than thinning out.

The option is commented rather than deleted, with the reason beside it, so the intent survives a later upgrade that fixes the emission path and someone can simply uncomment it.

Worth recording why the obvious signals were no help, since anyone hitting this again will meet them first. `service_graphs_edges` climbs normally while `expired_edges` stays flat, which reads as edges completing; grafana/tempo#5319 redefined `expired_edges` to exclude edges counted in the graph, so a flat counter is equally what a broken emission path looks like and cannot separate the two. Ingestion, remote-write and the receiving Prometheus were all measured clean, and span metrics never stopped, so every health indicator pointed away from the processor. What settled it was registry arithmetic - the current `traces_*` series accounted for the whole of `tempo_metrics_generator_registry_active_series` with no service-graph series among them.

The docs change records why the option is off, and drops a stale clause claiming the 60s `wait` exists for span pairs arriving via tail sampling. That has not been true since #270 removed Alloy tail sampling.

## Verification

`make validate` passes both targets - the Alloy River config parses and `kubectl kustomize deployment/` renders cleanly - and the rendered `tempo` ConfigMap was parsed back to confirm the key is absent from `service_graphs` rather than merely commented in the source.

Behaviour was checked by running `grafana/tempo:3.0.3` against the rendered ConfigMap with its generator pointed at a Prometheus started with `--web.enable-remote-write-receiver`, then replaying a trace of the failing shape: one `server` span whose parent lies outside the trace, plus `client` spans carrying `peer.service`. At the production `wait: 60s` all seven service-graph series appeared at t+80s with the expected `connection_type=virtual_node` label. The same rig with the option restored produced none, which is the comparison the fix rests on.

This repository has no unit tests; CI runs a Trivy config scan and applies the manifests to a kind cluster, neither of which would catch a generator emitting fewer series than intended.
