### PR TITLE
docs(tracing): document NodeJS instrumentation alongside Beyla

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ kubectl port-forward -n monitoring svc/grafana 3000:3000
 
 Grafana open and composable [observability stack](https://grafana.com/about/grafana-stack/)
 
+## Instrumenting your applications
+
+[Beyla](./docs/beyla.md) gives you spans with no code changes, which is the fastest way to get traces flowing. It cannot propagate trace context across a process boundary, though, so traces stop at each service and Tempo's service graph can only draw virtual nodes for the peers it infers.
+
+For NodeJS services, [`@saidsef/tracing-node`](https://github.com/saidsef/tracing-node) covers that gap. It wraps the OpenTelemetry SDK with HTTP, fetch/undici, Express, Elasticsearch, IORedis, AWS SDK and Pino instrumentation, and registers the W3C Trace Context propagator, so a call from one service to another arrives as a child span in the same trace. That is what turns Tempo's service graph from a list of virtual nodes into real service-to-service edges.
+
+```shell
+npm install @saidsef/tracing-node --save
+```
+
+```javascript
+import { setupTracing } from '@saidsef/tracing-node';
+setupTracing({serviceName: 'my-service', url: 'http://alloy:4317'});
+```
+
+Point `url` at the Alloy OTLP gRPC receiver deployed here, which forwards to Tempo. The two approaches compose - Beyla for services you cannot change, the SDK for the ones you can.
+
 ## Why make or use this?
 
 This is an attempt to demystify the different components of [LGTM+ Stack](https://github.com/grafana/helm-charts/tree/main/charts), deploying the full stack can seem overwhelming, breaking it down to smaller composable pieces will hopefully help you better understand each service and its configuration.

--- a/docs/tempo.md
+++ b/docs/tempo.md
@@ -135,6 +135,8 @@ otelcol.exporter.otlp "tempo" {
 
 The Jaeger and Zipkin receivers are available for services that instrument with those SDKs directly.
 
+For NodeJS services, [`@saidsef/tracing-node`](https://github.com/saidsef/tracing-node) wraps the OpenTelemetry SDK and registers the W3C Trace Context propagator. That propagation is what the `service-graphs` processor needs: without a client span carrying `traceparent` to the callee, each service starts its own trace and the graph can only ever show virtual nodes.
+
 ## Outputs
 
 Tempo is its own data source in Grafana at `http://tempo:3100`. It is also the linker that wires the rest of the stack together:


### PR DESCRIPTION
Fixes #282.

Adds an "Instrumenting your applications" section to the README and a matching note to the Tempo doc, covering the one thing the repository never said: how application spans reach the stack, and what a service graph needs beyond them.

The section is deliberately not a pitch for replacing Beyla. It states what Beyla does well - spans with no code changes, which is why it is the default here - and then the specific thing it cannot do, which is carry trace context across a process boundary. That limitation is what decides whether Tempo's `service-graphs` processor can pair a caller's client span with the callee's server span, and therefore whether the graph shows real edges or only virtual nodes inferred from peer attributes. Framing it that way means a reader can tell which of the two they need without having to discover the distinction from an empty-looking graph.

For NodeJS the section points at `@saidsef/tracing-node`, which wraps the OpenTelemetry SDK with the usual instrumentations and registers the W3C Trace Context propagator, with a two-line usage example aimed at the Alloy OTLP gRPC receiver this stack already deploys. The Tempo doc gets the same requirement recorded next to the ingest receivers, where someone configuring `service-graphs` will actually meet it.

The example sends traces to `alloy:4317` rather than `tempo:4317`. Both work, but Alloy is where the existing pipeline applies `k8sattributes` and batching before forwarding to Tempo, so pointing at Alloy keeps SDK traffic on the same path as everything else rather than bypassing that enrichment.

## Verification

`make validate` passes both targets - the Alloy River config parses and `kubectl kustomize deployment/` renders cleanly - though neither exercises documentation, so they only confirm nothing else was disturbed.

The claims in the prose were checked rather than assumed. Alloy's Service exposes 4317 alongside 4318 and 12345, so the endpoint in the example resolves against what this repository deploys. Every `github.com/saidsef/*` link across both changed files was followed and the referenced repository returns 200. The behaviour described - propagation producing a paired edge, and its absence producing a virtual node labelled `connection_type=virtual_node` - was confirmed end to end against Tempo 3.0.3 running this repository's Tempo ConfigMap, with two services calling each other over HTTP.
