### PR TITLE
feat(deployment): require amd64 or arm64 nodes for stack workloads

### DIFF
--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -24,6 +24,16 @@ spec:
     spec:
       serviceAccountName: alloy
       enableServiceLinks: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
       containers:
         - name: alloy
           image: docker.io/grafana/alloy:v1.18.1

--- a/deployment/beyla/daemonset.yml
+++ b/deployment/beyla/daemonset.yml
@@ -23,6 +23,16 @@ spec:
       hostPID: true
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
       containers:
         - name: beyla
           image: docker.io/grafana/beyla:3.32.0

--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -28,6 +28,16 @@ spec:
         runAsNonRoot: true
         runAsGroup: 10001
         runAsUser: 10001
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
       containers:
         - name: loki
           image: docker.io/grafana/loki:3.7.6

--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -23,6 +23,16 @@ spec:
     spec:
       serviceAccountName: mimir
       automountServiceAccountToken: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
       containers:
       - args:
         - '-config.file=/conf/mimir.yaml'

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -23,6 +23,16 @@ spec:
         runAsGroup: 10001
         runAsUser: 10001
         runAsNonRoot: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
       containers:
         - name: prometheus
           image: docker.io/prom/prometheus:v3.13.2

--- a/deployment/pyroscope/deployment.yml
+++ b/deployment/pyroscope/deployment.yml
@@ -25,6 +25,16 @@ spec:
         runAsNonRoot: true
         runAsGroup: 10001
         runAsUser: 10001
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
       containers:
       - name: pyroscope
         image: docker.io/grafana/pyroscope:2.2.1

--- a/deployment/tempo/statefulset.yml
+++ b/deployment/tempo/statefulset.yml
@@ -20,6 +20,16 @@ spec:
     spec:
       serviceAccountName: tempo
       automountServiceAccountToken: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
       containers:
       - args:
         - -config.file=/conf/tempo.yaml


### PR DESCRIPTION
Fixes #284.

Loki, Mimir, Tempo, Prometheus, Pyroscope, Beyla and Alloy each gain a `requiredDuringSchedulingIgnoredDuringExecution` node affinity on `kubernetes.io/arch`, admitting `amd64` and `arm64`. That pair is the intersection of the platforms the pinned images publish. Tempo, Pyroscope, Mimir and Beyla ship amd64 and arm64 only, while Loki adds arm, Alloy adds ppc64le and s390x, and Prometheus adds arm, ppc64le, riscv64 and s390x on top. The rule describes the set of nodes the whole stack already runs on, and narrows nothing that works today.

Beyla and Alloy are placed on every node the cluster has, including any node added after the fact, so they meet an unsupported architecture before any Deployment or StatefulSet would.

Required rather than preferred, because a preferred rule is only a tie-breaker: the scheduler still places the pod on an unsupported node once the preferred ones are full, which converts a clean scheduling failure back into the crash loop the rule was meant to prevent. Required means a node outside the set is never a candidate, and a pod that cannot be placed says so in its events. `IgnoredDuringExecution` is the only sensible half of the second clause, since a node's architecture does not change under a running pod.

Pods on amd64 and arm64 nodes are unaffected. The constraint only takes effect where a node runs some other architecture.

Running kubeconform in strict mode over the full `kubectl kustomize deployment/` render, against the v1.32.0 schema, returns 40 resources and all of them valid. `make validate` passes alongside it, so the Alloy River config formats cleanly and the kustomize build renders without error.