### PR TITLE
chore(deps): upgrade the stack images and repin Promtail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ALLOY_IMAGE    ?= docker.io/grafana/alloy:v1.18.1
+ALLOY_IMAGE    ?= docker.io/grafana/alloy:v1.19.2
 KIND_CLUSTER   ?= loki-stack
 KUBE_NAMESPACE ?= monitoring
 

--- a/deployment/alloy/daemonset.yml
+++ b/deployment/alloy/daemonset.yml
@@ -36,7 +36,7 @@ spec:
                       - arm64
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.18.1
+          image: docker.io/grafana/alloy:v1.19.2
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/deployment/grafana/deployment.yml
+++ b/deployment/grafana/deployment.yml
@@ -44,7 +44,7 @@ spec:
               subPath: dashboards
       containers:
       - name: grafana
-        image: docker.io/grafana/grafana:13.1.3
+        image: docker.io/grafana/grafana:13.2.1
         imagePullPolicy: IfNotPresent
         env:
         - name: GOMAXPROCS

--- a/deployment/loki/statefulset.yml
+++ b/deployment/loki/statefulset.yml
@@ -40,7 +40,7 @@ spec:
                       - arm64
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.7.6
+          image: docker.io/grafana/loki:3.7.7
           imagePullPolicy: IfNotPresent
           args:
             - -target=all

--- a/deployment/mimir/statefulset.yml
+++ b/deployment/mimir/statefulset.yml
@@ -38,7 +38,7 @@ spec:
         - '-config.file=/conf/mimir.yaml'
         - '-log.format=json'
         - '-log.level=warn'
-        image: docker.io/grafana/mimir:3.1.4
+        image: docker.io/grafana/mimir:3.2.0
         imagePullPolicy: IfNotPresent
         name: mimir
         env:

--- a/deployment/prometheus/deployment.yml
+++ b/deployment/prometheus/deployment.yml
@@ -35,7 +35,7 @@ spec:
                       - arm64
       containers:
         - name: prometheus
-          image: docker.io/prom/prometheus:v3.13.2
+          image: docker.io/prom/prometheus:v3.14.0
           imagePullPolicy: IfNotPresent
           env:
             - name: GOMAXPROCS

--- a/deployment/promtail/daemonset.yml
+++ b/deployment/promtail/daemonset.yml
@@ -24,7 +24,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:3.7.2
+          image: docker.io/grafana/promtail:3.6.11
           imagePullPolicy: IfNotPresent
           env:
           - name: HOSTNAME

--- a/deployment/pyroscope/deployment.yml
+++ b/deployment/pyroscope/deployment.yml
@@ -37,7 +37,7 @@ spec:
                       - arm64
       containers:
       - name: pyroscope
-        image: docker.io/grafana/pyroscope:2.2.1
+        image: docker.io/grafana/pyroscope:2.3.0
         imagePullPolicy: IfNotPresent
         args:
           - "-config.file=/etc/pyroscope/config.yaml"

--- a/docs/alloy.md
+++ b/docs/alloy.md
@@ -6,7 +6,7 @@ This stack uses Alloy in place of Promtail. The Promtail directory is still in t
 
 ## What it runs
 
-- DaemonSet, image `docker.io/grafana/alloy:v1.18.1`.
+- DaemonSet, image `docker.io/grafana/alloy:v1.19.2`.
 - Args: `run /etc/alloy/config.alloy --storage.path=/tmp/alloy --server.http.listen-addr=$(POD_IP):12345 --server.http.ui-path-prefix=/ --stability.level=public-preview --feature.community-components.enabled --cluster.enabled=true --cluster.name=$(CLUSTER_NAME) --cluster.wait-for-size=1`.
 - `CLUSTER_NAME` is read from the pod label `cluster` via the downward API, so it's set in the DaemonSet pod template rather than hardcoded in the args.
 - Ports: 12345 (HTTP UI and self metrics), 4317 (OTLP gRPC), 4318 (OTLP HTTP).

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -6,7 +6,7 @@ The cross-data-source linking (logs to traces, traces to logs / metrics / profil
 
 ## What it runs
 
-- Deployment, single replica, image `docker.io/grafana/grafana:13.1.3`.
+- Deployment, single replica, image `docker.io/grafana/grafana:13.2.1`.
 - Port: 3000 (HTTP). Service `grafana` exposes the same port.
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 768Mi. `GOMAXPROCS` and `GOMEMLIMIT` are bound to those limits via `resourceFieldRef`.
 - Storage: 4 Gi emptyDir at `/var/lib/grafana`, split by subPath into `grafana` (state), `dashboards` (provisioned dashboards) and `tmp`.

--- a/docs/loki.md
+++ b/docs/loki.md
@@ -6,7 +6,7 @@ It is single tenant (`auth_enabled: false`), no replication, no external ring. A
 
 ## What it runs
 
-- StatefulSet, single replica, image `docker.io/grafana/loki:3.7.6`.
+- StatefulSet, single replica, image `docker.io/grafana/loki:3.7.7`.
 - Args: `-target=all -config.file=/etc/loki/loki.yaml`.
 - Port: 3100 (HTTP). Service `loki` exposes the same port.
 - Resources: requests 50m CPU / 512Mi, limits 100m CPU / 768Mi.

--- a/docs/mimir.md
+++ b/docs/mimir.md
@@ -4,7 +4,7 @@ Mimir is the long-term metrics store. It runs in single-binary mode (`target: al
 
 ## What it runs
 
-- StatefulSet, single replica, image `docker.io/grafana/mimir:3.1.4`.
+- StatefulSet, single replica, image `docker.io/grafana/mimir:3.2.0`.
 - Args (besides `-config.file=/conf/mimir.yaml`): `-auth.multitenancy-enabled=false -auth.no-auth-tenant=anonymous -compactor.blocks-retention-period=15d -distributor.ha-tracker.enable-for-all-users=true -querier.cardinality-analysis-enabled=true -blocks-storage.storage-prefix=blocks -ingester.out-of-order-time-window=15m -log.format=json -log.level=warn`.
 - Ports: 8080 (HTTP, exposed on the Service as port 80), 9095 (gRPC).
 - Resources: requests 100m CPU / 512Mi, limits 100m CPU / 768Mi.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -6,7 +6,7 @@ The `remote_write` to Mimir is intentionally commented out. Alloy writes to both
 
 ## What it runs
 
-- Deployment, single replica, image `docker.io/prom/prometheus:v3.13.2`.
+- Deployment, single replica, image `docker.io/prom/prometheus:v3.14.0`.
 - Args: `--storage.tsdb.retention.time=15d --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/prometheus/data/ --web.enable-remote-write-receiver --web.enable-otlp-receiver --web.enable-lifecycle --enable-feature=concurrent-rule-eval,promql-experimental-functions,exemplar-storage,promql-per-step-stats,native-histograms --log.level=warn --log.format=json`.
 - Port: 9090 (exposed on the Service `prometheus-server` as port 80).
 - Resources: requests 100m CPU / 512Mi, limits 150m CPU / 894Mi.

--- a/docs/pyroscope.md
+++ b/docs/pyroscope.md
@@ -4,7 +4,7 @@ Pyroscope is the continuous-profiling backend. Profile scraping is handled by [A
 
 ## What it runs
 
-- Deployment, single replica, image `docker.io/grafana/pyroscope:2.2.1`.
+- Deployment, single replica, image `docker.io/grafana/pyroscope:2.3.0`.
 - Args: `-config.file=/etc/pyroscope/config.yaml -runtime-config.file=/etc/pyroscope/overrides/overrides.yaml -log.level=info`. All other configuration is in `config.yaml` — log level is the one flag Pyroscope does not expose in the config file.
 - Ports: 4040 (HTTP, ingest and query), 9095 (gRPC), 7946 (memberlist).
 - Resources: requests 100m CPU / 512Mi, limits 200m CPU / 768Mi.


### PR DESCRIPTION
## Summary

Six of the stack images move up one release: Alloy, Grafana, Loki, Mimir, Prometheus and Pyroscope. Promtail moves the other way, from a tag that was never published down to 3.6.11, the last one Grafana shipped. The docs pages and the Makefile name these tags too, so they move with the manifests.

| Component | From | To |
| --- | --- | --- |
| Alloy | v1.18.1 | v1.19.2 |
| Grafana | 13.1.3 | 13.2.1 |
| Loki | 3.7.6 | 3.7.7 |
| Mimir | 3.1.4 | 3.2.0 |
| Prometheus | v3.13.2 | v3.14.0 |
| Pyroscope | 2.2.1 | 2.3.0 |
| Promtail | 3.7.2 | 3.6.11 |

## Related Issues

Refs #286. The Kind node alignment that issue also asks for is not in this branch.

## Changes Made

Grafana stopped publishing Promtail at 3.6.11 and the registry returns a 404 for 3.7.2, so the only way to correct that pin is downwards. The promtail directory is commented out of the kustomization, so nothing was pulling the broken tag.

The Makefile keeps its own Alloy pin, which `make validate-config` uses to run `alloy fmt` over the ConfigMap. That now matches the DaemonSet, so the config is checked against the version that will run it.

## Testing

- `kubectl kustomize deployment/` - renders clean
- `make validate-config` - Alloy config: OK, against v1.19.2
- `curl` against the Docker Hub tag API for all eight pins - the seven in the tree resolve, `promtail:3.7.2` returns 404

## Checklist

- [x] The per-component docs name the tags now in the manifests
- [x] The Makefile Alloy pin matches the DaemonSet